### PR TITLE
second entry fix

### DIFF
--- a/implementation/FileSkeleton/src/createVector.hpp.in
+++ b/implementation/FileSkeleton/src/createVector.hpp.in
@@ -5,8 +5,8 @@ createVector
 
   std::vector< SectionSkeleton_t > vector;
   vector.emplace_back( head, begin, position, end, lineNumber );
+  begin = position; 
   auto division = StructureDivision( position, end, lineNumber );
-  
   while( division.isHead() ){
     vector.emplace_back( asHead(division), begin, position, end, lineNumber );
     if( position >= end ){

--- a/implementation/MaterialSkeleton/src/createVector.hpp.in
+++ b/implementation/MaterialSkeleton/src/createVector.hpp.in
@@ -5,6 +5,7 @@ createVector
 
   std::vector< FileSkeleton_t > vector;
   vector.emplace_back( head, begin, position, end, lineNumber );
+  begin = position;
   auto division = StructureDivision( position, end, lineNumber ); 
 
   while( division.isHead() ){

--- a/implementation/TapeSkeleton/src/createVector.hpp.in
+++ b/implementation/TapeSkeleton/src/createVector.hpp.in
@@ -10,6 +10,7 @@ createVector
   auto begin = position;
   auto division = structureDivision();
   vector.emplace_back( asHead( division ), begin, position, end, lineNumber );
+  begin = position;
   if( position >= end ){
     LOG(ERROR) <<
       "Tape encountered end of stream before reading TEND record";


### PR DESCRIPTION
Corrected a bug in which the second section of a file, the second file of a material, and the second material of a tape would include the (respective) first within the buffer. 