### PR TITLE
Feature/mf3

### DIFF
--- a/src/ENDFtk/section/1/451.hpp
+++ b/src/ENDFtk/section/1/451.hpp
@@ -1,6 +1,6 @@
 template<>
 class Type< 1, 451 > : protected Base {
-protected:
+
   /* fields */
   int lrp_;
   int lfi_;
@@ -11,10 +11,13 @@ protected:
   std::vector< DirectoryRecord > index_;
 
   /* auxiliary functions */
+  #include "ENDFtk/section/1/451/src/makeParameters.hpp"
+  #include "ENDFtk/section/1/451/src/makeDescription.hpp"
   #include "ENDFtk/section/1/451/src/readParameters.hpp"
   #include "ENDFtk/section/1/451/src/readRecords.hpp"
 
-  public:
+public:
+
   /* constructor */
   #include "ENDFtk/section/1/451/src/ctor.hpp"
 
@@ -43,10 +46,7 @@ protected:
   int NWD() const { return static_cast< int >( this->description_.size() ); }
   int NXC() const { return static_cast< int >( this->index_.size() ); }
 
-  auto index() const {
-    return ranges::make_iterator_range( this->index_.begin(),
-                                        this->index_.end() );
-  }
+  auto index() const { return ranges::view::all( this->index_ ); }
 
   long NC() const { return 4 + this->NWD() + this->NXC(); }
 

--- a/src/ENDFtk/section/1/451/src/ctor.hpp
+++ b/src/ENDFtk/section/1/451/src/ctor.hpp
@@ -1,3 +1,28 @@
+Type( double zaid, double awr, int lrp, int lfi, int nlib, int nmod,
+      std::array< ControlRecord, 3 >&& parameters,
+      std::vector< TextRecord >&& description,
+      std::vector< DirectoryRecord >&& index ) :
+  Base( zaid, awr, 1 ), lrp_( lrp ), lfi_( lfi ), nlib_( nlib ), nmod_( nmod ),
+  parameters_( std::move( parameters ) ),
+  description_( std::move( description ) ),
+  index_( std::move( index ) ) {}
+
+Type( double zaid, double awr, int lrp, int lfi, int nlib, int nmod,
+      double elis, double sta, int lis, int liso, int nfor,
+      double awi, double emax, int lrel, int nsub, int nver,
+      double temp, int ldrv,
+      const std::string& description,
+      std::vector< DirectoryRecord >&& index ) :
+  Base( zaid, awr, 1 ), lrp_( lrp ), lfi_( lfi ), nlib_( nlib ), nmod_( nmod ),
+  parameters_( makeParameters( elis, sta, lis, liso, nfor,
+                               awi, emax, lrel, nsub, nver,
+                               temp, ldrv, 
+                               ranges::distance(
+                                   ranges::view::split( description, '\n' ) ),
+                               index.size() ) ),
+  description_( makeDescription( description ) ),
+  index_( std::move( index ) ) {}
+
 template< typename Iterator >
 Type ( HEAD& head,
        Iterator& begin,

--- a/src/ENDFtk/section/1/451/src/makeDescription.hpp
+++ b/src/ENDFtk/section/1/451/src/makeDescription.hpp
@@ -1,0 +1,8 @@
+static
+std::vector< TextRecord >
+makeDescription( const std::string& description ) {
+
+  return ranges::view::split( description, '\n' )
+           | ranges::view::transform( [] ( const auto& line )
+                                         { return TextRecord( line ); } );
+}

--- a/src/ENDFtk/section/1/451/src/makeParameters.hpp
+++ b/src/ENDFtk/section/1/451/src/makeParameters.hpp
@@ -1,0 +1,10 @@
+static auto
+makeParameters( double elis, double sta, int lis, int liso, int nfor,
+                double awi, double emax, int lrel, int nsub, int nver,
+                double temp, int ldrv, int nwd, int nxc ) {
+
+  auto line0 = ControlRecord( elis, sta, lis, liso, 0, nfor );
+  auto line1 = ControlRecord( awi, emax, lrel, 0, nsub, nver );
+  auto line2 = ControlRecord( temp, 0.0, ldrv, 0, nwd, nxc );
+  return std::array< ControlRecord, 3 >{{ line0, line1, line2 }};
+}

--- a/src/ENDFtk/section/1/451/test/451.test.cpp
+++ b/src/ENDFtk/section/1/451/test/451.test.cpp
@@ -53,7 +53,7 @@ SCENARIO( "section::Type< 1, 451 >" ) {
                                      awi, emax, lrel, nsub, nver,
                                      temp, ldrv,
                                      text,
-                                     std::move( index() ) );
+                                     index() );
 
       REQUIRE( 451 == chunk.MT() );
       REQUIRE( 1001 == chunk.ZA() );
@@ -96,7 +96,7 @@ SCENARIO( "section::Type< 1, 451 >" ) {
       section::Type< 1, 451 > chunk( zaid, awr, lrp, lfi, nlib, nmod,
                                      std::move( parameters ),
                                      std::move( records ),
-                                     std::move( index() ) );
+                                     index() );
 
       REQUIRE( 451 == chunk.MT() );
       REQUIRE( 1001 == chunk.ZA() );

--- a/src/ENDFtk/section/1/451/test/451.test.cpp
+++ b/src/ENDFtk/section/1/451/test/451.test.cpp
@@ -18,7 +18,7 @@ std::string invalidSEND();
 
 SCENARIO( "section::Type< 1, 451 >" ) {
 
-  GIVEN( "valid data for a section::Type< 3 >" ) {
+  GIVEN( "valid data for a section::Type< 1, 451 >" ) {
 
     int zaid = 1001;
     double awr = 0.9991673;
@@ -57,6 +57,7 @@ SCENARIO( "section::Type< 1, 451 >" ) {
 
       REQUIRE( 451 == chunk.MT() );
       REQUIRE( 1001 == chunk.ZA() );
+      REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
       REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
       REQUIRE( 1 == chunk.LRP() );
       REQUIRE( 2 == chunk.LFI() );
@@ -100,6 +101,7 @@ SCENARIO( "section::Type< 1, 451 >" ) {
 
       REQUIRE( 451 == chunk.MT() );
       REQUIRE( 1001 == chunk.ZA() );
+      REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
       REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
       REQUIRE( 1 == chunk.LRP() );
       REQUIRE( 2 == chunk.LFI() );
@@ -151,6 +153,7 @@ SCENARIO( "section::Type< 1, 451 >" ) {
 
         REQUIRE( 451 == chunk.MT() );
         REQUIRE( 1001 == chunk.ZA() );
+        REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
         REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
         REQUIRE( 1 == chunk.LRP() );
         REQUIRE( 2 == chunk.LFI() );
@@ -203,6 +206,7 @@ SCENARIO( "section::Type< 1, 451 >" ) {
 
         REQUIRE( 451 == chunk.MT() );
         REQUIRE( 1001 == chunk.ZA() );
+        REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
         REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
         REQUIRE( 1 == chunk.LRP() );
         REQUIRE( 2 == chunk.LFI() );

--- a/src/ENDFtk/section/1/451/test/451.test.cpp
+++ b/src/ENDFtk/section/1/451/test/451.test.cpp
@@ -7,63 +7,187 @@ using namespace njoy::ENDFtk;
 
 using section1451 = section::Type< 1, 451 >;
 
-std::string baseSection451();
-std::string invalidNWDSection451();
-std::string invalidNXCSection451();
+std::string chunk();
+std::string invalidNWD();
+std::string invalidNXC();
 std::string description();
+std::vector< TextRecord > textRecords();
 std::vector< DirectoryRecord > index();
 std::string validSEND();
 std::string invalidSEND();
 
 SCENARIO( "section::Type< 1, 451 >" ) {
-  GIVEN( "a string representation of a valid File 1 Section 451" ) {
+
+  GIVEN( "valid data for a section::Type< 3 >" ) {
+
+    int zaid = 1001;
+    double awr = 0.9991673;
+    int lrp = 1;
+    int lfi = 2;
+    int nlib = 3;
+    int nmod = 4;
+    double elis = 5.;
+    double sta = 6.;
+    int lis = 7;
+    int liso = 8;
+    int nfor = 12;
+    double awi = 13.;
+    double emax = 14.;
+    int lrel = 15;
+    int nsub = 17;
+    int nver = 18;
+    double temp = 19.;
+    int ldrv = 21;
+    std::array< ControlRecord, 3 > parameters = 
+        {{ ControlRecord( elis, sta, lis, liso, 0, nfor ),
+           ControlRecord( awi, emax, lrel, 0, nsub, nver ),
+           ControlRecord( temp, 0.0, ldrv, 0, 9, 10 ) }};
+    std::string text = description();
+    std::vector< TextRecord > records = textRecords();
+
+    THEN( "a section::Type< 1, 451 > can be constructed and "
+          "members can be tested" ) {
+
+      section::Type< 1, 451 > chunk( zaid, awr, lrp, lfi, nlib, nmod,
+                                     elis, sta, lis, liso, nfor,
+                                     awi, emax, lrel, nsub, nver,
+                                     temp, ldrv,
+                                     text,
+                                     std::move( index() ) );
+
+      REQUIRE( 451 == chunk.MT() );
+      REQUIRE( 1001 == chunk.ZA() );
+      REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+      REQUIRE( 1 == chunk.LRP() );
+      REQUIRE( 2 == chunk.LFI() );
+      REQUIRE( 3 == chunk.NLIB() );
+      REQUIRE( 4 == chunk.NMOD() );
+      REQUIRE( 5.0 == Approx( chunk.ELIS() ) );
+      REQUIRE( 6.0 == Approx( chunk.STA() ) );
+      REQUIRE( 7 == chunk.LIS() );
+      REQUIRE( 8 == chunk.LISO() );
+      REQUIRE( 12 == chunk.NFOR() );
+      REQUIRE( 13.0 == Approx( chunk.AWI() ) );
+      REQUIRE( 14.0 == Approx( chunk.EMAX() ) );
+      REQUIRE( 15 == chunk.LREL() );
+      REQUIRE( 17 == chunk.NSUB() );
+      REQUIRE( 18 == chunk.NVER() );
+      REQUIRE( 19.0 == Approx( chunk.TEMP() ) );
+      REQUIRE( 21 == chunk.LDRV() );
+      REQUIRE( 9 == chunk.NWD() );
+      REQUIRE( ranges::equal( description(), chunk.description() ) );
+
+      auto entries = index();
+      REQUIRE( entries.size() == chunk.NXC() );
+      for ( unsigned int i = 0; i < entries.size(); ++i ) {
+
+        REQUIRE( entries[i].MF() == chunk.index()[i].MF() );
+        REQUIRE( entries[i].MT() == chunk.index()[i].MT() );
+        REQUIRE( entries[i].NC() == chunk.index()[i].NC() );
+        REQUIRE( entries[i].MOD() == chunk.index()[i].MOD() );
+      }
+
+      REQUIRE( 23 == chunk.NC() );
+    } // THEN
+
+    THEN( "a section::Type< 1, 451 > can be constructed and "
+          "members can be tested" ) {
+
+      section::Type< 1, 451 > chunk( zaid, awr, lrp, lfi, nlib, nmod,
+                                     std::move( parameters ),
+                                     std::move( records ),
+                                     std::move( index() ) );
+
+      REQUIRE( 451 == chunk.MT() );
+      REQUIRE( 1001 == chunk.ZA() );
+      REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+      REQUIRE( 1 == chunk.LRP() );
+      REQUIRE( 2 == chunk.LFI() );
+      REQUIRE( 3 == chunk.NLIB() );
+      REQUIRE( 4 == chunk.NMOD() );
+      REQUIRE( 5.0 == Approx( chunk.ELIS() ) );
+      REQUIRE( 6.0 == Approx( chunk.STA() ) );
+      REQUIRE( 7 == chunk.LIS() );
+      REQUIRE( 8 == chunk.LISO() );
+      REQUIRE( 12 == chunk.NFOR() );
+      REQUIRE( 13.0 == Approx( chunk.AWI() ) );
+      REQUIRE( 14.0 == Approx( chunk.EMAX() ) );
+      REQUIRE( 15 == chunk.LREL() );
+      REQUIRE( 17 == chunk.NSUB() );
+      REQUIRE( 18 == chunk.NVER() );
+      REQUIRE( 19.0 == Approx( chunk.TEMP() ) );
+      REQUIRE( 21 == chunk.LDRV() );
+      REQUIRE( 9 == chunk.NWD() );
+      REQUIRE( ranges::equal( description(), chunk.description() ) );
+
+      auto entries = index();
+      REQUIRE( entries.size() == chunk.NXC() );
+      for ( unsigned int i = 0; i < entries.size(); ++i ) {
+
+        REQUIRE( entries[i].MF() == chunk.index()[i].MF() );
+        REQUIRE( entries[i].MT() == chunk.index()[i].MT() );
+        REQUIRE( entries[i].NC() == chunk.index()[i].NC() );
+        REQUIRE( entries[i].MOD() == chunk.index()[i].MOD() );
+      }
+
+      REQUIRE( 23 == chunk.NC() );
+    } // THEN
+  } // GIVEN
+
+  GIVEN( "a valid string representation of a section::Type< 1, 451 >" ) {
+
     WHEN( "there is a valid SEND record" ){
-      std::string sectionString = baseSection451() + validSEND();
+
+      std::string sectionString = chunk() + validSEND();
       auto begin = sectionString.begin();
       auto end = sectionString.end();
       long lineNumber = 1; 
       HeadRecord head( begin, end, lineNumber );
       
-      THEN( "a section::Type< 1, 451 > can be constructed and members can be tested" ) {
-        section::Type< 1, 451 > MF1MT451( head, begin, end, lineNumber, 125 );
-        REQUIRE( 451 == MF1MT451.MT() );
-        REQUIRE( 1001 == MF1MT451.ZA() );
-        REQUIRE( 0.9991673 == Approx( MF1MT451.atomicWeightRatio() ) );
-        REQUIRE( 1 == MF1MT451.LRP() );
-        REQUIRE( 2 == MF1MT451.LFI() );
-        REQUIRE( 3 == MF1MT451.NLIB() );
-        REQUIRE( 4 == MF1MT451.NMOD() );
-        REQUIRE( 5.0 == Approx( MF1MT451.ELIS() ) );
-        REQUIRE( 6.0 == Approx( MF1MT451.STA() ) );
-        REQUIRE( 7 == MF1MT451.LIS() );
-        REQUIRE( 8 == MF1MT451.LISO() );
-        REQUIRE( 12 == MF1MT451.NFOR() );
-        REQUIRE( 13.0 == Approx( MF1MT451.AWI() ) );
-        REQUIRE( 14.0 == Approx( MF1MT451.EMAX() ) );
-        REQUIRE( 15 == MF1MT451.LREL() );
-        REQUIRE( 17 == MF1MT451.NSUB() );
-        REQUIRE( 18 == MF1MT451.NVER() );
-        REQUIRE( 19.0 == Approx( MF1MT451.TEMP() ) );
-        REQUIRE( 21 == MF1MT451.LDRV() );
-        REQUIRE( 9 == MF1MT451.NWD() );
-        REQUIRE( ranges::equal( description(), MF1MT451.description() ) );
+      THEN( "a section::Type< 1, 451 > can be constructed and "
+            "members can be tested" ) {
+
+        section::Type< 1, 451 > chunk( head, begin, end, lineNumber, 125 );
+
+        REQUIRE( 451 == chunk.MT() );
+        REQUIRE( 1001 == chunk.ZA() );
+        REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+        REQUIRE( 1 == chunk.LRP() );
+        REQUIRE( 2 == chunk.LFI() );
+        REQUIRE( 3 == chunk.NLIB() );
+        REQUIRE( 4 == chunk.NMOD() );
+        REQUIRE( 5.0 == Approx( chunk.ELIS() ) );
+        REQUIRE( 6.0 == Approx( chunk.STA() ) );
+        REQUIRE( 7 == chunk.LIS() );
+        REQUIRE( 8 == chunk.LISO() );
+        REQUIRE( 12 == chunk.NFOR() );
+        REQUIRE( 13.0 == Approx( chunk.AWI() ) );
+        REQUIRE( 14.0 == Approx( chunk.EMAX() ) );
+        REQUIRE( 15 == chunk.LREL() );
+        REQUIRE( 17 == chunk.NSUB() );
+        REQUIRE( 18 == chunk.NVER() );
+        REQUIRE( 19.0 == Approx( chunk.TEMP() ) );
+        REQUIRE( 21 == chunk.LDRV() );
+        REQUIRE( 9 == chunk.NWD() );
+        REQUIRE( ranges::equal( description(), chunk.description() ) );
 
         auto entries = index();
-        REQUIRE( entries.size() == MF1MT451.NXC() );
+        REQUIRE( entries.size() == chunk.NXC() );
         for ( unsigned int i = 0; i < entries.size(); ++i ) {
 
-          REQUIRE( entries[i].MF() == MF1MT451.index()[i].MF() );
-          REQUIRE( entries[i].MT() == MF1MT451.index()[i].MT() );
-          REQUIRE( entries[i].NC() == MF1MT451.index()[i].NC() );
-          REQUIRE( entries[i].MOD() == MF1MT451.index()[i].MOD() );
+          REQUIRE( entries[i].MF() == chunk.index()[i].MF() );
+          REQUIRE( entries[i].MT() == chunk.index()[i].MT() );
+          REQUIRE( entries[i].NC() == chunk.index()[i].NC() );
+          REQUIRE( entries[i].MOD() == chunk.index()[i].MOD() );
         }
 
-        REQUIRE( 23 == MF1MT451.NC() );
-      }
-    }
+        REQUIRE( 23 == chunk.NC() );
+      } // THEN
+    } // WHEN
 
     WHEN( "there is a syntaxTree::Section" ){
-      std::string sectionString = baseSection451() + validSEND();
+
+      std::string sectionString = chunk() + validSEND();
       auto begin = sectionString.begin();
       auto position = begin;
       auto end = sectionString.end();
@@ -72,59 +196,66 @@ SCENARIO( "section::Type< 1, 451 >" ) {
       syntaxTree::Section< std::string::iterator >
         section( head, begin, position, end, lineNumber );
       
-      THEN( "a section::Type< 1, 451 > can be constructed and members can be tested" ){
-        section::Type< 1, 451 > MF1MT451 = section.parse< 1, 451 >( lineNumber );
-        REQUIRE( 451 == MF1MT451.MT() );
-        REQUIRE( 1001 == MF1MT451.ZA() );
-        REQUIRE( 0.9991673 == Approx( MF1MT451.atomicWeightRatio() ) );
-        REQUIRE( 1 == MF1MT451.LRP() );
-        REQUIRE( 2 == MF1MT451.LFI() );
-        REQUIRE( 3 == MF1MT451.NLIB() );
-        REQUIRE( 4 == MF1MT451.NMOD() );
-        REQUIRE( 5.0 == Approx( MF1MT451.ELIS() ) );
-        REQUIRE( 6.0 == Approx( MF1MT451.STA() ) );
-        REQUIRE( 7 == MF1MT451.LIS() );
-        REQUIRE( 8 == MF1MT451.LISO() );
-        REQUIRE( 12 == MF1MT451.NFOR() );
-        REQUIRE( 13.0 == Approx( MF1MT451.AWI() ) );
-        REQUIRE( 14.0 == Approx( MF1MT451.EMAX() ) );
-        REQUIRE( 15 == MF1MT451.LREL() );
-        REQUIRE( 17 == MF1MT451.NSUB() );
-        REQUIRE( 18 == MF1MT451.NVER() );
-        REQUIRE( 19.0 == Approx( MF1MT451.TEMP() ) );
-        REQUIRE( 21 == MF1MT451.LDRV() );
-        REQUIRE( 9 == MF1MT451.NWD() );
-        REQUIRE( ranges::equal( description(), MF1MT451.description() ) );
+      THEN( "a section::Type< 1, 451 > can be constructed and "
+            "members can be tested" ) {
+
+        section::Type< 1, 451 > chunk = section.parse< 1, 451 >( lineNumber );
+
+        REQUIRE( 451 == chunk.MT() );
+        REQUIRE( 1001 == chunk.ZA() );
+        REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+        REQUIRE( 1 == chunk.LRP() );
+        REQUIRE( 2 == chunk.LFI() );
+        REQUIRE( 3 == chunk.NLIB() );
+        REQUIRE( 4 == chunk.NMOD() );
+        REQUIRE( 5.0 == Approx( chunk.ELIS() ) );
+        REQUIRE( 6.0 == Approx( chunk.STA() ) );
+        REQUIRE( 7 == chunk.LIS() );
+        REQUIRE( 8 == chunk.LISO() );
+        REQUIRE( 12 == chunk.NFOR() );
+        REQUIRE( 13.0 == Approx( chunk.AWI() ) );
+        REQUIRE( 14.0 == Approx( chunk.EMAX() ) );
+        REQUIRE( 15 == chunk.LREL() );
+        REQUIRE( 17 == chunk.NSUB() );
+        REQUIRE( 18 == chunk.NVER() );
+        REQUIRE( 19.0 == Approx( chunk.TEMP() ) );
+        REQUIRE( 21 == chunk.LDRV() );
+        REQUIRE( 9 == chunk.NWD() );
+
+        REQUIRE( ranges::equal( description(), chunk.description() ) );
 
         auto entries = index();
-        REQUIRE( entries.size() == MF1MT451.NXC() );
+        REQUIRE( entries.size() == chunk.NXC() );
         for ( unsigned int i = 0; i < entries.size(); ++i ) {
 
-          REQUIRE( entries[i].MF() == MF1MT451.index()[i].MF() );
-          REQUIRE( entries[i].MT() == MF1MT451.index()[i].MT() );
-          REQUIRE( entries[i].NC() == MF1MT451.index()[i].NC() );
-          REQUIRE( entries[i].MOD() == MF1MT451.index()[i].MOD() );
+          REQUIRE( entries[i].MF() == chunk.index()[i].MF() );
+          REQUIRE( entries[i].MT() == chunk.index()[i].MT() );
+          REQUIRE( entries[i].NC() == chunk.index()[i].NC() );
+          REQUIRE( entries[i].MOD() == chunk.index()[i].MOD() );
         }
 
-        REQUIRE( 23 == MF1MT451.NC() );
-      }
-    }
+        REQUIRE( 23 == chunk.NC() );
+      } // THEN
+    } // WHEN
     
-    WHEN( "the SEND Record is not valid, i.e., MT != 0" ){
-      std::string sectionString = baseSection451() + invalidSEND();
+    WHEN( "the SEND Record is not valid, i.e., MT != 0" ) {
+
+      std::string sectionString = chunk() + invalidSEND();
       auto begin = sectionString.begin();
       auto end = sectionString.end();
       long lineNumber = 1;
       HeadRecord head( begin, end, lineNumber );
       
       THEN( "an exception is thrown" ){
+
         REQUIRE_THROWS( section1451( head, begin, end, lineNumber, 125 ) );
-      }
-    } 
+      } // THEN
+    } // WHEN
   } // GIVEN
 
   GIVEN( "a valid instance of section::Type< 1, 451 >" ) {
-    std::string string = baseSection451() + validSEND();
+
+    std::string string = chunk() + validSEND();
     auto begin = string.begin();
     auto end = string.end();
     long lineNumber = 1; 
@@ -132,41 +263,46 @@ SCENARIO( "section::Type< 1, 451 >" ) {
     section::Type< 1, 451 > section( head, begin, end, lineNumber, 125 );
 
     THEN( "it can be printed" ) {
+
       std::string buffer;
       auto output = std::back_inserter( buffer );
       section.print( output, 125, 1 );
       REQUIRE( buffer == string );
-    }
+    } // THEN
   } // GIVEN
 
   GIVEN( "a string representation of an File 1 Section 451"
-         " with an invalid NWD (comment lines)" ){
-    std::string sectionString = invalidNWDSection451() + validSEND();
+         " with an invalid NWD (comment lines)" ) {
+
+    std::string sectionString = invalidNWD() + validSEND();
+    auto begin = sectionString.begin();
+    auto end = sectionString.end();
+    long lineNumber = 1;
+    HeadRecord head( begin, end, lineNumber );
+    
+    THEN( "an exception is thrown upon construction" ) {
+
+      REQUIRE_THROWS( section1451( head, begin, end, lineNumber, 125 ) );
+    } // THEN
+  } // GIVEN
+
+  GIVEN( "a string representation of an File 1 Section 451"
+         " with an invalid NXC (index lines)" ) {
+
+    std::string sectionString = invalidNXC() + validSEND();
     auto begin = sectionString.begin();
     auto end = sectionString.end();
     long lineNumber = 1;
     HeadRecord head( begin, end, lineNumber );
     
     THEN( "an exception is thrown upon construction" ){
-      REQUIRE_THROWS( section1451( head, begin, end, lineNumber, 125 ) );
-    }
-  } // GIVEN
 
-  GIVEN( "a string representation of an File 1 Section 451"
-         " with an invalid NXC (index lines)" ){
-    std::string sectionString = invalidNXCSection451() + validSEND();
-    auto begin = sectionString.begin();
-    auto end = sectionString.end();
-    long lineNumber = 1;
-    HeadRecord head( begin, end, lineNumber );
-    
-    THEN( "an exception is thrown upon construction" ){
       REQUIRE_THROWS( section1451( head, begin, end, lineNumber, 125 ) );
-    }
+    } // THEN
   } // GIVEN
 } // SCENARIO
 
-std::string baseSection451() {
+std::string chunk() {
   // Please note that the numbers in the first 4 records are actually
   // randomly set to test if the correct value is extracted instead of using
   // ENDF legal values
@@ -196,7 +332,7 @@ std::string baseSection451() {
     "                               33        102         21          5 125 1451     \n";
 }
 
-std::string invalidNWDSection451() {
+std::string invalidNWD() {
   return
     " 1.001000+3 9.991673-1          0          0          0          5 125 1451     \n"
     " 0.000000+0 0.000000+0          0          0          0          6 125 1451     \n"
@@ -223,7 +359,7 @@ std::string invalidNWDSection451() {
     "                               33        102         21          5 125 1451     \n";
 }
 
-std::string invalidNXCSection451() {
+std::string invalidNXC() {
   return
     " 1.001000+3 9.991673-1          0          0          0          5 125 1451     \n"
     " 0.000000+0 0.000000+0          0          0          0          6 125 1451     \n"
@@ -261,6 +397,19 @@ std::string description() {
     " **************************************************************** \n"
     "                                                                  \n"
     " **************************************************************** \n";
+}
+
+std::vector< TextRecord > textRecords() {
+  return
+    { { "  1-H -  1 LANL       EVAL-JUL16 G.M.Hale                         " },
+      { "                      DIST-JAN17                       20170124   " },
+      { "----ENDF/B-VIII.0     MATERIAL  125                               " },
+      { "-----INCIDENT NEUTRON DATA                                        " },
+      { "------ENDF-6 FORMAT                                               " },
+      { "                                                                  " },
+      { " **************************************************************** " },
+      { "                                                                  " },
+      { " **************************************************************** " } };
 }
 
 std::vector< DirectoryRecord > index() {

--- a/src/ENDFtk/section/3.hpp
+++ b/src/ENDFtk/section/3.hpp
@@ -1,19 +1,36 @@
 template<>
 class Type< 3 > : protected Base {
-public:
 
   /* fields */
   TabulationRecord table;
 
-  /* methods */
-#include "ENDFtk/section/3/src/ctor.hpp"
+public:
 
-#include "ENDFtk/section/3/src/print.hpp"
+  /* constructor */
+  #include "ENDFtk/section/3/src/ctor.hpp"
+
+  /* get methods */
+  double QM() const { return this->table.C1(); }
+  double massDifferenceQValue() const { return this->QM(); }
+  double QI() const { return this->table.C2(); }
+  double reactionQValue() const { return this->QI(); }
+  int LR() const { return this->table.L2(); }
+  int complexBreakUp() const { return this->LR(); }
+  long NR() const { return this->table.NR(); }
+  long NP() const { return this->table.NP(); }
+
+  auto interpolants() const { return this->table.interpolants(); }
+  auto boundaries() const { return this->table.boundaries(); }
+  auto energies() const { return this->table.x(); }
+  auto crossSections() const { return this->table.y(); }
+
+  long NC() const { return this->table.NC() + 1; }
+
+  #include "ENDFtk/section/3/src/print.hpp"
     
   using Base::MT;
   using Base::ZA;
+  using Base::AWR;
   using Base::atomicWeightRatio;
-
-  int LR() const { return this->table.L2(); }
 };
 

--- a/src/ENDFtk/section/3/src/ctor.hpp
+++ b/src/ENDFtk/section/3/src/ctor.hpp
@@ -1,3 +1,11 @@
+Type( int MT, double zaid, double awr, double qm, double qi, long lr,
+      std::vector< long >&& boundaries, std::vector< long >&& interpolants,
+      std::vector< double >&& energies, std::vector< double >&& xs ) :
+  Base( zaid, awr, MT ),
+  table( qm, qi, 0, lr,
+         std::move( boundaries ), std::move( interpolants ),
+         std::move( energies ), std::move( xs ) ) {}
+
 template< typename Iterator >
 Type ( HEAD& head, 
        Iterator& begin, 

--- a/src/ENDFtk/section/3/test/3.test.cpp
+++ b/src/ENDFtk/section/3/test/3.test.cpp
@@ -1,166 +1,226 @@
-#define CATCH_CONFIG_MAIN     
-     
-#include "catch.hpp"     
-#include "ENDFtk.hpp"     
-     
-std::string baseSection();     
-std::string invalidBaseSection();     
-std::string validSEND();     
-std::string invalidSEND();     
-     
-using namespace njoy::ENDFtk;     
-     
-SCENARIO( "section::Type<3>" ){     
-  GIVEN( "a string representation of a valid File 3 Section" ){     
-    WHEN( "there is a valid SEND record" ){     
-      std::string sectionString = baseSection() + validSEND();     
-      auto begin = sectionString.begin();     
-      auto end = sectionString.end();     
-      long lineNumber = 132;      
-      HeadRecord head( begin, end, lineNumber );     
-           
-      THEN( "a section::Type<3> can be constructed and members can be tested" ){     
-        section::Type<3> MF3( head, begin, end, lineNumber, 125 );     
-        REQUIRE( 1 == MF3.MT() );     
-        REQUIRE( 1001 == MF3.ZA() );     
-        REQUIRE( 0.9991673 == MF3.atomicWeightRatio() );     
-        REQUIRE( 0 == MF3.LR() );
-      }     
-    }     
-     
-    WHEN( "there is a syntaxTree::Section" ){     
-      std::string sectionString = baseSection() + validSEND();     
-      auto begin = sectionString.begin();     
-      auto position = begin;     
-      auto end = sectionString.end();     
-      long lineNumber = 0;     
-      auto head = HEAD( position, end, lineNumber );     
-      syntaxTree::Section< std::string::iterator >     
-        mf3( head, begin, position, end, lineNumber );     
-           
-      THEN( "a section::Type<3> can be constructed and members can be tested" ){     
-        section::Type<3> MF3 = mf3.parse<3>( lineNumber );     
-        REQUIRE( 1 == MF3.MT() );     
-        REQUIRE( 1001 == MF3.ZA() );     
-        REQUIRE( 0.9991673 == MF3.atomicWeightRatio() );     
-      }     
-    }     
+#define CATCH_CONFIG_MAIN
 
-    WHEN( "the SEND Record is not valid, i.e., MT!=0" ){     
-      std::string sectionString = baseSection() + invalidSEND();     
-      auto begin = sectionString.begin();     
-      auto end = sectionString.end();     
-      long lineNumber = 132;     
-      HeadRecord head( begin, end, lineNumber );     
-           
-      THEN( "an exception is thrown" ){     
-        REQUIRE_THROWS( section::Type<3>( head, begin, end, lineNumber, 125 ) );     
-      }     
-    }      
-  }      
+#include "catch.hpp"
+#include "ENDFtk.hpp"
+
+std::string chunk();
+std::string validSEND();
+std::string invalidSEND();
+
+using namespace njoy::ENDFtk;
+
+SCENARIO( "section::Type< 3 >" ) {
+
+  GIVEN( "valid data for a section::Type< 3 >" ) {
+
+    int mt = 102;
+    int zaid = 1001;
+    int lr = 0;
+    double awr = 0.9991673;
+    double qm = 2.224648e+6;
+    double qi = 3.224648e+6;
+    std::vector< long > interpolants = { 5, 2 };
+    std::vector< long > boundaries = { 3, 6 };
+    std::vector< double > energies = { 1e-5, 2e-5, 7.5e+5,
+                                       1.9e+7, 1.95e+7, 2e+7 };
+    std::vector< double > xs = { 1.672869e+1, 1.182897e+1, 3.347392e-5,
+                                 2.751761e-5, 2.731301e-5, 2.710792e-5 };
+
+    THEN( "a section::Type< 3 > can be constructed and "
+          "members can be tested" ) {
+
+      section::Type< 3 > chunk( mt, zaid, awr, qm, qi, lr,
+                                std::move( boundaries ),
+                                std::move( interpolants ), 
+                                std::move( energies ), std::move( xs ) );
+
+      REQUIRE( 102 == chunk.MT() );
+      REQUIRE( 1001 == chunk.ZA() );
+      REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
+      REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+      REQUIRE( 0 == chunk.LR() );
+      REQUIRE( 0 == chunk.complexBreakUp() );
+      REQUIRE( 2.224648e+6 == Approx( chunk.QM() ) );
+      REQUIRE( 2.224648e+6 == Approx( chunk.massDifferenceQValue() ) );
+      REQUIRE( 3.224648e+6 == Approx( chunk.QI() ) );
+      REQUIRE( 3.224648e+6 == Approx( chunk.reactionQValue() ) );
+
+      REQUIRE( 6 == chunk.NP() );
+      REQUIRE( 2 == chunk.NR() );
+      REQUIRE( 2 == chunk.interpolants().size() );
+      REQUIRE( 2 == chunk.boundaries().size() );
+      REQUIRE( 5 == chunk.interpolants()[0] );
+      REQUIRE( 2 == chunk.interpolants()[1] );
+      REQUIRE( 3 == chunk.boundaries()[0] );
+      REQUIRE( 6 == chunk.boundaries()[1] );
+      REQUIRE( 6 == chunk.energies().size() );
+      REQUIRE( 6 == chunk.crossSections().size() );
+      REQUIRE( 1e-5 == Approx( chunk.energies()[0] ) );
+      REQUIRE( 2e-5 == Approx( chunk.energies()[1] ) );
+      REQUIRE( 7.5e+5 == Approx( chunk.energies()[2] ) );
+      REQUIRE( 1.9e+7 == Approx( chunk.energies()[3] ) );
+      REQUIRE( 1.95e+7 == Approx( chunk.energies()[4] ) );
+      REQUIRE( 2e+7 == Approx( chunk.energies()[5] ) );
+      REQUIRE( 1.672869e+1 == Approx( chunk.crossSections()[0] ) );
+      REQUIRE( 1.182897e+1 == Approx( chunk.crossSections()[1] ) );
+      REQUIRE( 3.347392e-5 == Approx( chunk.crossSections()[2] ) );
+      REQUIRE( 2.751761e-5 == Approx( chunk.crossSections()[3] ) );
+      REQUIRE( 2.731301e-5 == Approx( chunk.crossSections()[4] ) );
+      REQUIRE( 2.710792e-5 == Approx( chunk.crossSections()[5] ) );
+
+      REQUIRE( 5 == chunk.NC() );
+    } // THEN
+  } // GIVEN
+
+  GIVEN( "a valid string representation of a section::Type< 3 >" ) {
+
+    WHEN( "there is a valid SEND record" ) {
+      std::string sectionString = chunk() + validSEND();
+      auto begin = sectionString.begin();
+      auto end = sectionString.end();
+      long lineNumber = 0;
+      HeadRecord head( begin, end, lineNumber );
+
+      THEN( "a section::Type< 3 > can be constructed and "
+            "members can be tested" ) {
+
+        section::Type< 3 > chunk( head, begin, end, lineNumber, 125 );
+
+        REQUIRE( 102 == chunk.MT() );
+        REQUIRE( 1001 == chunk.ZA() );
+        REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
+        REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+        REQUIRE( 0 == chunk.LR() );
+        REQUIRE( 0 == chunk.complexBreakUp() );
+        REQUIRE( 2.224648e+6 == Approx( chunk.QM() ) );
+        REQUIRE( 2.224648e+6 == Approx( chunk.massDifferenceQValue() ) );
+        REQUIRE( 3.224648e+6 == Approx( chunk.QI() ) );
+        REQUIRE( 3.224648e+6 == Approx( chunk.reactionQValue() ) );
+
+        REQUIRE( 6 == chunk.NP() );
+        REQUIRE( 2 == chunk.NR() );
+        REQUIRE( 2 == chunk.interpolants().size() );
+        REQUIRE( 2 == chunk.boundaries().size() );
+        REQUIRE( 5 == chunk.interpolants()[0] );
+        REQUIRE( 2 == chunk.interpolants()[1] );
+        REQUIRE( 3 == chunk.boundaries()[0] );
+        REQUIRE( 6 == chunk.boundaries()[1] );
+        REQUIRE( 6 == chunk.energies().size() );
+        REQUIRE( 6 == chunk.crossSections().size() );
+        REQUIRE( 1e-5 == Approx( chunk.energies()[0] ) );
+        REQUIRE( 2e-5 == Approx( chunk.energies()[1] ) );
+        REQUIRE( 7.5e+5 == Approx( chunk.energies()[2] ) );
+        REQUIRE( 1.9e+7 == Approx( chunk.energies()[3] ) );
+        REQUIRE( 1.95e+7 == Approx( chunk.energies()[4] ) );
+        REQUIRE( 2e+7 == Approx( chunk.energies()[5] ) );
+        REQUIRE( 1.672869e+1 == Approx( chunk.crossSections()[0] ) );
+        REQUIRE( 1.182897e+1 == Approx( chunk.crossSections()[1] ) );
+        REQUIRE( 3.347392e-5 == Approx( chunk.crossSections()[2] ) );
+        REQUIRE( 2.751761e-5 == Approx( chunk.crossSections()[3] ) );
+        REQUIRE( 2.731301e-5 == Approx( chunk.crossSections()[4] ) );
+        REQUIRE( 2.710792e-5 == Approx( chunk.crossSections()[5] ) );
+
+        REQUIRE( 5 == chunk.NC() );
+      } // THEN
+    } // WHEN
+
+    WHEN( "there is a syntaxTree::Section" ){
+      std::string sectionString = chunk() + validSEND();
+      auto begin = sectionString.begin();
+      auto position = begin;
+      auto end = sectionString.end();
+      long lineNumber = 0;
+      auto head = HEAD( position, end, lineNumber );
+      syntaxTree::Section< std::string::iterator >
+        section( head, begin, position, end, lineNumber );
+
+      THEN( "a section::Type<3> can be constructed and members can be tested" ){
+
+        section::Type<3> chunk = section.parse< 3 >( lineNumber );
+
+        REQUIRE( 102 == chunk.MT() );
+        REQUIRE( 1001 == chunk.ZA() );
+        REQUIRE( 0.9991673 == Approx( chunk.AWR() ) );
+        REQUIRE( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+        REQUIRE( 0 == chunk.LR() );
+        REQUIRE( 0 == chunk.complexBreakUp() );
+        REQUIRE( 2.224648e+6 == Approx( chunk.QM() ) );
+        REQUIRE( 2.224648e+6 == Approx( chunk.massDifferenceQValue() ) );
+        REQUIRE( 3.224648e+6 == Approx( chunk.QI() ) );
+        REQUIRE( 3.224648e+6 == Approx( chunk.reactionQValue() ) );
+
+        REQUIRE( 6 == chunk.NP() );
+        REQUIRE( 2 == chunk.NR() );
+        REQUIRE( 2 == chunk.interpolants().size() );
+        REQUIRE( 2 == chunk.boundaries().size() );
+        REQUIRE( 5 == chunk.interpolants()[0] );
+        REQUIRE( 2 == chunk.interpolants()[1] );
+        REQUIRE( 3 == chunk.boundaries()[0] );
+        REQUIRE( 6 == chunk.boundaries()[1] );
+        REQUIRE( 6 == chunk.energies().size() );
+        REQUIRE( 6 == chunk.crossSections().size() );
+        REQUIRE( 1e-5 == Approx( chunk.energies()[0] ) );
+        REQUIRE( 2e-5 == Approx( chunk.energies()[1] ) );
+        REQUIRE( 7.5e+5 == Approx( chunk.energies()[2] ) );
+        REQUIRE( 1.9e+7 == Approx( chunk.energies()[3] ) );
+        REQUIRE( 1.95e+7 == Approx( chunk.energies()[4] ) );
+        REQUIRE( 2e+7 == Approx( chunk.energies()[5] ) );
+        REQUIRE( 1.672869e+1 == Approx( chunk.crossSections()[0] ) );
+        REQUIRE( 1.182897e+1 == Approx( chunk.crossSections()[1] ) );
+        REQUIRE( 3.347392e-5 == Approx( chunk.crossSections()[2] ) );
+        REQUIRE( 2.751761e-5 == Approx( chunk.crossSections()[3] ) );
+        REQUIRE( 2.731301e-5 == Approx( chunk.crossSections()[4] ) );
+        REQUIRE( 2.710792e-5 == Approx( chunk.crossSections()[5] ) );
+
+        REQUIRE( 5 == chunk.NC() );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the SEND Record is not valid, i.e., MT!=0" ){
+      std::string sectionString = chunk() + invalidSEND();
+      auto begin = sectionString.begin();
+      auto end = sectionString.end();
+      long lineNumber = 0;
+      HeadRecord head( begin, end, lineNumber );
+
+      THEN( "an exception is thrown" ){
+        REQUIRE_THROWS( section::Type<3>( head, begin, end, lineNumber, 125 ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
 
   GIVEN( "a valid instance of section::Type< 3 >" ) {
-    std::string string = baseSection() + validSEND();
+    std::string string = chunk() + validSEND();
     auto begin = string.begin();
     auto end = string.end();
-    long lineNumber = 1; 
+    long lineNumber = 1;
     HeadRecord head( begin, end, lineNumber );
-    section::Type< 3 > section( head, begin, end, lineNumber, 125 );
+    section::Type< 3 > chunk( head, begin, end, lineNumber, 125 );
 
     THEN( "it can be printed" ) {
       std::string buffer;
       auto output = std::back_inserter( buffer );
-      section.print( output, 125, 3 );
+      chunk.print( output, 125, 3 );
       REQUIRE( buffer == string );
-    }
+    } // THEN
   } // GIVEN
-} // SCENARIO     
-     
-std::string baseSection(){     
-  return     
-    " 1.001000+3 9.991673-1          0          0          0          0 125 3  1     \n"     
-    " 0.000000+0 0.000000+0          0          0          2         96 125 3  1     \n"     
-    "         30          5         96          2                       125 3  1     \n"     
-    " 1.000000-5 3.713628+1 2.000000-5 3.224498+1 5.000000-5 2.790478+1 125 3  1     \n"     
-    " 1.000000-4 2.571732+1 2.000000-4 2.417056+1 5.000000-4 2.279806+1 125 3  1     \n"     
-    " 1.000000-3 2.210633+1 2.000000-3 2.161720+1 5.000000-3 2.118318+1 125 3  1     \n"     
-    " 1.000000-2 2.096443+1 2.530000-2 2.076834+1 5.000000-2 2.067250+1 125 3  1     \n"     
-    " 1.000000-1 2.060332+1 2.000000-1 2.055439+1 5.000000-1 2.051095+1 125 3  1     \n"     
-    " 1.000000+0 2.048901+1 2.000000+0 2.047341+1 5.000000+0 2.045928+1 125 3  1     \n"     
-    " 1.000000+1 2.045169+1 2.000000+1 2.044545+1 5.000000+1 2.043707+1 125 3  1     \n"     
-    " 1.000000+2 2.042815+1 2.000000+2 2.041317+1 5.000000+2 2.037161+1 125 3  1     \n"     
-    " 1.000000+3 2.030435+1 2.000000+3 2.017221+1 4.000000+3 1.991433+1 125 3  1     \n"     
-    " 6.000000+3 1.966407+1 8.000000+3 1.942096+1 1.000000+4 1.918468+1 125 3  1     \n"     
-    " 1.500000+4 1.862195+1 2.000000+4 1.809600+1 4.000000+4 1.629575+1 125 3  1     \n"     
-    " 6.000000+4 1.486744+1 8.000000+4 1.370595+1 1.000000+5 1.274239+1 125 3  1     \n"     
-    " 1.500000+5 1.092347+1 2.000000+5 9.643237+0 3.000000+5 7.951994+0 125 3  1     \n"     
-    " 4.000000+5 6.876451+0 5.000000+5 6.125481+0 6.000000+5 5.566913+0 125 3  1     \n"     
-    " 7.000000+5 5.132043+0 8.000000+5 4.781603+0 9.000000+5 4.491504+0 125 3  1     \n"     
-    " 1.000000+6 4.246138+0 1.200000+6 3.850489+0 1.400000+6 3.541783+0 125 3  1     \n"     
-    " 1.600000+6 3.291349+0 1.800000+6 3.082224+0 2.000000+6 2.903682+0 125 3  1     \n"     
-    " 2.200000+6 2.748580+0 2.400000+6 2.611955+0 2.600000+6 2.490235+0 125 3  1     \n"     
-    " 2.800000+6 2.380773+0 3.000000+6 2.281558+0 3.200000+6 2.191030+0 125 3  1     \n"     
-    " 3.400000+6 2.107954+0 3.600000+6 2.031337+0 3.800000+6 1.960371+0 125 3  1     \n"     
-    " 4.000000+6 1.894386+0 4.200000+6 1.832823+0 4.400000+6 1.775213+0 125 3  1     \n"     
-    " 4.600000+6 1.721153+0 4.800000+6 1.670299+0 5.000000+6 1.622354+0 125 3  1     \n"     
-    " 5.500000+6 1.513587+0 6.000000+6 1.418191+0 6.500000+6 1.333743+0 125 3  1     \n"     
-    " 7.000000+6 1.258400+0 7.500000+6 1.190730+0 8.000000+6 1.129596+0 125 3  1     \n"     
-    " 8.500000+6 1.074084+0 9.000000+6 1.023447+0 9.500000+6 9.770666-1 125 3  1     \n"     
-    " 1.000000+7 9.344290-1 1.050000+7 8.950999-1 1.100000+7 8.587108-1 125 3  1     \n"     
-    " 1.150000+7 8.249463-1 1.200000+7 7.935351-1 1.250000+7 7.642418-1 125 3  1     \n"     
-    " 1.300000+7 7.368615-1 1.350000+7 7.112148-1 1.400000+7 6.871439-1 125 3  1     \n"     
-    " 1.450000+7 6.645095-1 1.500000+7 6.431880-1 1.550000+7 6.230693-1 125 3  1     \n"     
-    " 1.600000+7 6.040552-1 1.650000+7 5.860577-1 1.700000+7 5.689977-1 125 3  1     \n"     
-    " 1.750000+7 5.528040-1 1.800000+7 5.374121-1 1.850000+7 5.227637-1 125 3  1     \n"     
-    " 1.900000+7 5.088059-1 1.950000+7 4.954905-1 2.000000+7 4.827735-1 125 3  1     \n";     
-}     
-     
-std::string invalidBaseSection(){     
-  return      
-    " 1.001000+3 9.991673-1          0          0          0          0 125 3  1     \n"     
-    " 0.000000+0 0.000000+0          0          0          2         96 125 3  1     \n"     
-    "         30          5         96          2                       125 3  1     \n"     
-    " 1.000000-5-3.713628+1 2.000000-5 3.224498+1 5.000000-5 2.790478+1 125 3  1     \n"     
-    " 1.000000-4 2.571732+1 2.000000-4 2.417056+1 5.000000-4 2.279806+1 125 3  1     \n"     
-    " 1.000000-3 2.210633+1 2.000000-3 2.161720+1 5.000000-3 2.118318+1 125 3  1     \n"     
-    " 1.000000-2 2.096443+1 2.530000-2 2.076834+1 5.000000-2 2.067250+1 125 3  1     \n"     
-    " 1.000000-1 2.060332+1 2.000000-1 2.055439+1 5.000000-1 2.051095+1 125 3  1     \n"     
-    " 1.000000+0 2.048901+1 2.000000+0 2.047341+1 5.000000+0 2.045928+1 125 3  1     \n"     
-    " 1.000000+1 2.045169+1 2.000000+1 2.044545+1 5.000000+1 2.043707+1 125 3  1     \n"     
-    " 1.000000+2 2.042815+1 2.000000+2 2.041317+1 5.000000+2 2.037161+1 125 3  1     \n"     
-    " 1.000000+3 2.030435+1 2.000000+3 2.017221+1 4.000000+3 1.991433+1 125 3  1     \n"     
-    " 6.000000+3 1.966407+1 8.000000+3 1.942096+1 1.000000+4 1.918468+1 125 3  1     \n"     
-    " 1.500000+4 1.862195+1 2.000000+4 1.809600+1 4.000000+4 1.629575+1 125 3  1     \n"     
-    " 6.000000+4 1.486744+1 8.000000+4 1.370595+1 1.000000+5 1.274239+1 125 3  1     \n"     
-    " 1.500000+5 1.092347+1 2.000000+5 9.643237+0 3.000000+5 7.951994+0 125 3  1     \n"     
-    " 4.000000+5 6.876451+0 5.000000+5 6.125481+0 6.000000+5 5.566913+0 125 3  1     \n"     
-    " 7.000000+5 5.132043+0 8.000000+5 4.781603+0 9.000000+5 4.491504+0 125 3  1     \n"     
-    " 1.000000+6 4.246138+0 1.200000+6 3.850489+0 1.400000+6 3.541783+0 125 3  1     \n"     
-    " 1.600000+6 3.291349+0 1.800000+6 3.082224+0 2.000000+6 2.903682+0 125 3  1     \n"     
-    " 2.200000+6 2.748580+0 2.400000+6 2.611955+0 2.600000+6 2.490235+0 125 3  1     \n"     
-    " 2.800000+6 2.380773+0 3.000000+6 2.281558+0 3.200000+6 2.191030+0 125 3  1     \n"     
-    " 3.400000+6 2.107954+0 3.600000+6 2.031337+0 3.800000+6 1.960371+0 125 3  1     \n"     
-    " 4.000000+6 1.894386+0 4.200000+6 1.832823+0 4.400000+6 1.775213+0 125 3  1     \n"     
-    " 4.600000+6 1.721153+0 4.800000+6 1.670299+0 5.000000+6 1.622354+0 125 3  1     \n"     
-    " 5.500000+6 1.513587+0 6.000000+6 1.418191+0 6.500000+6 1.333743+0 125 3  1     \n"     
-    " 7.000000+6 1.258400+0 7.500000+6 1.190730+0 8.000000+6 1.129596+0 125 3  1     \n"     
-    " 8.500000+6 1.074084+0 9.000000+6 1.023447+0 9.500000+6 9.770666-1 125 3  1     \n"     
-    " 1.000000+7 9.344290-1 1.050000+7 8.950999-1 1.100000+7 8.587108-1 125 3  1     \n"     
-    " 1.150000+7 8.249463-1 1.200000+7 7.935351-1 1.250000+7 7.642418-1 125 3  1     \n"     
-    " 1.300000+7 7.368615-1 1.350000+7 7.112148-1 1.400000+7 6.871439-1 125 3  1     \n"     
-    " 1.450000+7 6.645095-1 1.500000+7 6.431880-1 1.550000+7 6.230693-1 125 3  1     \n"     
-    " 1.600000+7 6.040552-1 1.650000+7 5.860577-1 1.700000+7 5.689977-1 125 3  1     \n"     
-    " 1.750000+7 5.528040-1 1.800000+7 5.374121-1 1.850000+7 5.227637-1 125 3  1     \n"     
-    " 1.900000+7 5.088059-1 1.950000+7 4.954905-1 2.000000+7 4.827735-1 125 3  1     \n"     
-    "                                                                   125 3  0     \n";     
-}     
-     
-std::string validSEND(){     
-  return     
-    "                                                                   125 3  0     \n";     
+} // SCENARIO
+
+std::string chunk(){
+  return
+    " 1.001000+3 9.991673-1          0          0          0          0 125 3102     \n"
+    " 2.224648+6 3.224648+6          0          0          2          6 125 3102     \n"
+    "          3          5          6          2                       125 3102     \n"
+    " 1.000000-5 1.672869+1 2.000000-5 1.182897+1 7.500000+5 3.347392-5 125 3102     \n"
+    " 1.900000+7 2.751761-5 1.950000+7 2.731301-5 2.000000+7 2.710792-5 125 3102     \n";
 }
 
-std::string invalidSEND(){     
-  return     
-    "                                                                   125 3  1     \n";     
+std::string validSEND(){
+  return
+    "                                                                   125 3  0     \n";
+}
+
+std::string invalidSEND(){
+  return
+    "                                                                   125 3  1     \n";
 }

--- a/src/ENDFtk/section/3/test/3.test.cpp
+++ b/src/ENDFtk/section/3/test/3.test.cpp
@@ -134,7 +134,8 @@ SCENARIO( "section::Type< 3 >" ) {
       syntaxTree::Section< std::string::iterator >
         section( head, begin, position, end, lineNumber );
 
-      THEN( "a section::Type<3> can be constructed and members can be tested" ){
+      THEN( "a section::Type< 3 > can be constructed and "
+            "members can be tested" ) {
 
         section::Type<3> chunk = section.parse< 3 >( lineNumber );
 


### PR DESCRIPTION
This pull requests makes a few changes to MF3 and adds additional capabilities for MF1 MT451 and MF3. The following is a summary of changes:
- make the TAB1 inside an MF3 section private and provide accessor functions to the underlying data
- provide constructors to build an MF3 and MF1 MT451 section from scratch
- provide print() and NC() functions as required
- modified tests accordingly

These changes were made to allow for IRDF style data formatting.