### PR TITLE
Feature/mf2

### DIFF
--- a/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited.hpp
+++ b/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited.hpp
@@ -73,26 +73,6 @@ public:
   }
 
   /**
-   *  @brief Return the target spin
-   */
-  double SPI() const { return 1.0; } //!@todo PLACEHOLDER - CHANGE THIS
-
-  /**
-   *  @brief Return the target spin
-   */
-  double spin() const { return this->SPI(); }
-
-  /**
-   *  @brief Return the scattering radius
-   */
-  double AP() const { return 2.0; } //!@todo PLACEHOLDER - CHANGE THIS
-
-  /**
-   *  @brief Return the scattering radius
-   */
-  double scatteringRadius() const { return this->AP(); }
-
-  /**
    *  @brief Return whether or not the widths are reduced or not
    */
   bool IFG() const { return this->ifg_; }
@@ -141,6 +121,19 @@ public:
    *  @brief Return the spin groups
    */
   auto spinGroups() const { return ranges::view::all( this->spin_groups_ ); }
+
+  #include "ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/SPI.hpp"
+  #include "ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/AP.hpp"
+
+  /**
+   *  @brief Return the target spin
+   */
+  double spin() const { return this->SPI(); }
+
+  /**
+   *  @brief Return the scattering radius
+   */
+  double scatteringRadius() const { return this->AP(); }
 
   #include "ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/NC.hpp"
   #include "ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/print.hpp"

--- a/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited.hpp
+++ b/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited.hpp
@@ -73,6 +73,26 @@ public:
   }
 
   /**
+   *  @brief Return the target spin
+   */
+  double SPI() const { return 1.0; } //!@todo PLACEHOLDER - CHANGE THIS
+
+  /**
+   *  @brief Return the target spin
+   */
+  double spin() const { return this->SPI(); }
+
+  /**
+   *  @brief Return the scattering radius
+   */
+  double AP() const { return 2.0; } //!@todo PLACEHOLDER - CHANGE THIS
+
+  /**
+   *  @brief Return the scattering radius
+   */
+  double scatteringRadius() const { return this->AP(); }
+
+  /**
    *  @brief Return whether or not the widths are reduced or not
    */
   bool IFG() const { return this->ifg_; }

--- a/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/AP.hpp
+++ b/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/AP.hpp
@@ -1,5 +1,10 @@
 /**
- *  @brief Return the target spin
+ *  @brief Return the scattering radius
+ *
+ *  This function will only return the first true scattering radius value it
+ *  finds in the first spin group. If other spin groups use different radii,
+ *  AP is meaningless and should not be used as a shortcut to retrieve
+ *  the scattering radius.
  */
 double AP() const {
 

--- a/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/AP.hpp
+++ b/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/AP.hpp
@@ -1,0 +1,15 @@
+/**
+ *  @brief Return the target spin
+ */
+double AP() const {
+
+  auto mt = this->particlePairs().MT();
+  unsigned int elastic = ranges::distance( ranges::begin( mt ),
+                                           ranges::find( mt, int( 2 ) ) ) + 1;
+
+  auto channels = this->spinGroups().front().channels();
+  auto ppi = channels.particlePairNumbers();
+  unsigned int index = ranges::distance( ranges::begin( ppi ),
+                                         ranges::find( ppi, int( elastic ) ) );
+  return channels.trueChannelRadii()[index];
+};

--- a/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/SPI.hpp
+++ b/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/src/SPI.hpp
@@ -1,0 +1,10 @@
+/**
+ *  @brief Return the target spin
+ */
+double SPI() const {
+
+  auto mt = this->particlePairs().MT();
+  unsigned int index = ranges::distance( ranges::begin( mt ),
+                                         ranges::find( mt, int( 2 ) ) );
+  return this->particlePairs().spinParticleB()[index];
+};

--- a/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/test/RMatrixLimited.test.cpp
+++ b/src/ENDFtk/resonanceParameters/resolved/RMatrixLimited/test/RMatrixLimited.test.cpp
@@ -164,6 +164,11 @@ void verifyChunk( const RMatrixLimited& chunk ) {
   CHECK( 3 == chunk.KRM() );
   CHECK( 3 == chunk.formalism() );
 
+  CHECK( 0. == Approx( chunk.SPI() ) );
+  CHECK( 0. == Approx( chunk.spin() ) );
+  CHECK( 5.437300e-1 == Approx( chunk.AP() ) );
+  CHECK( 5.437300e-1 == Approx( chunk.scatteringRadius() ) );
+
   auto pairs = chunk.particlePairs();
   CHECK( 2 == pairs.NPP() );
   CHECK( 2 == pairs.numberParticlePairs() );


### PR DESCRIPTION
Added a function to return SPI and AP for LRF7, to be similar to what other resonance formalisms return.

Beware: while SPI will return the spin of the target, AP will only return the first true scattering radius value it finds in the first spin group. If other spin groups use different radii, AP is meaningless and should not be used as a shortcut to retrieve the scattering radius.