### PR TITLE
Fixing g++ ranges compilation error

### DIFF
--- a/src/ENDFtk/section/6/ContinuumEnergyAngle/LegendreCoefficients/src/generateList.hpp
+++ b/src/ENDFtk/section/6/ContinuumEnergyAngle/LegendreCoefficients/src/generateList.hpp
@@ -1,5 +1,5 @@
 static std::vector< double >
-generateList( unsigned int na, 
+generateList( unsigned int na,
               std::vector< double >&& energies,
               std::vector< std::vector< double > >&& coefficients ) {
 
@@ -27,5 +27,5 @@ generateList( unsigned int na,
   return ranges::view::zip_with(
              ranges::view::concat,
              energies | ranges::view::transform( ranges::view::single ),
-             coefficients ) | ranges::view::join;
+             coefficients ) | ranges::view::join | ranges::to_vector;
 }


### PR DESCRIPTION
CI now works on release but I had to fix a ranges compilation error.

CI will by default trigger the release version, we'll need to fix that. And from now on, build/fetchcontent (aka develop for lack of a better name) is now a protected branch. Hurrah!