### PR TITLE
Feature/tree

### DIFF
--- a/python/src/tree/File.python.cpp
+++ b/python/src/tree/File.python.cpp
@@ -50,8 +50,17 @@ void wrapTreeFile( python::module& module ) {
   );
 
   // wrap the tree component
-  // no __init__ since we do not want to create this object in python
+  // only copy is allowed since we do not want to create this object in python
   tree
+  .def(
+
+    python::init< const File& >(),
+    python::arg( "file" ),
+    "Initialise the file with another file\n\n"
+    "Arguments:\n"
+    "    self    the file\n"
+    "    file    the file to be copied"
+  )
   .def_property_readonly(
 
     "MAT",

--- a/python/src/tree/Material.python.cpp
+++ b/python/src/tree/Material.python.cpp
@@ -35,8 +35,17 @@ void wrapTreeMaterial( python::module& module ) {
   );
 
   // wrap the tree component
-  // no __init__ since we do not want to create this object in python
+  // only copy is allowed since we do not want to create this object in python
   tree
+  .def(
+
+    python::init< const Material& >(),
+    python::arg( "material" ),
+    "Initialise the material with another material\n\n"
+    "Arguments:\n"
+    "    self        the material\n"
+    "    material    the material to be copied"
+  )
   .def_property_readonly(
 
     "MAT",

--- a/python/src/tree/Section.python.cpp
+++ b/python/src/tree/Section.python.cpp
@@ -56,8 +56,17 @@ void wrapTreeSection( python::module& module ) {
   );
 
   // wrap the tree component
-  // no __init__ since we do not want to create this object in python
+  // only copy is allowed since we do not want to create this object in python
   tree
+  .def(
+
+    python::init< const Section& >(),
+    python::arg( "section" ),
+    "Initialise the section with another section\n\n"
+    "Arguments:\n"
+    "    self       the section\n"
+    "    section    the section to be copied"
+  )
   .def_property_readonly(
 
     "MAT",

--- a/python/test/Test_ENDFtk_Tree_Tape.py
+++ b/python/test/Test_ENDFtk_Tree_Tape.py
@@ -186,21 +186,27 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
 
                 verify_file1( self, material.MF( 1 ) )
                 verify_file1( self, material.file( 1 ) )
+                verify_file1( self, File( material.file( 1 ) ) )
 
                 verify_file2( self, material.MF( 2 ) )
                 verify_file2( self, material.file( 2 ) )
+                verify_file2( self, File( material.file( 2 ) ) )
 
                 verify_file3( self, material.MF( 3 ) )
                 verify_file3( self, material.file( 3 ) )
+                verify_file3( self, File( material.file( 3 ) ) )
 
                 verify_file4( self, material.MF( 4 ) )
                 verify_file4( self, material.file( 4 ) )
+                verify_file4( self, File( material.file( 4 ) ) )
 
                 verify_file6( self, material.MF( 6 ) )
                 verify_file6( self, material.file( 6 ) )
+                verify_file6( self, File( material.file( 6 ) ) )
 
                 verify_file33( self, material.MF( 33 ) )
                 verify_file33( self, material.file( 33 ) )
+                verify_file33( self, File( material.file( 33 ) ) )
 
                 self.assertEqual( 2209, len( material.content.split( '\n' ) ) )
 

--- a/python/test/Test_ENDFtk_Tree_Tape.py
+++ b/python/test/Test_ENDFtk_Tree_Tape.py
@@ -5,6 +5,9 @@ import unittest
 
 # local imports
 from ENDFtk.tree import Tape
+from ENDFtk.tree import Material
+from ENDFtk.tree import File
+from ENDFtk.tree import Section
 
 class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
     """Unit test for the Tape class."""
@@ -226,6 +229,9 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
 
             material = tape.material( 125 )
             verify_material( self, material )
+
+            copy = Material( material )
+            verify_material( self, copy )
 
             self.assertEqual( 2211, len( tape.content.split( '\n' ) ) )
 


### PR DESCRIPTION
A few simple changes:
- enabled the copy constructor on the ENDFtk tree components on the python side
- added some simple python unit testing on this new feature

The copy constructor on the tree.Material. tree.File and tree.Section is compiler generated but Austin did add tests for the copy and move constructor on the C++ side. As such, I am convinced the feature works as advertised. Tests in the python interpreter did not reveal issues.