### PR TITLE
Adding scheduled run for the workflow - should run every day now

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -2,7 +2,10 @@
 name: Continuous Integration
 
 # This workflow is triggered on pushes and pull requests to the repository.
+# This workflow will also run daily on the default branch (i.e. master)
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches: '**'
   pull_request:

--- a/src/ENDFtk/Material.hpp
+++ b/src/ENDFtk/Material.hpp
@@ -2,6 +2,7 @@
 #define NJOY_ENDFTK_MATERIAL
 
 // system includes
+#include <optional>
 
 // other includes
 #include "ENDFtk/file/1.hpp"

--- a/src/ENDFtk/Tape.hpp
+++ b/src/ENDFtk/Tape.hpp
@@ -2,6 +2,7 @@
 #define NJOY_ENDFTK_TAPE
 
 // system includes
+#include <optional>
 
 // other includes
 #include "range/v3/view/all.hpp"

--- a/src/ENDFtk/details.hpp
+++ b/src/ENDFtk/details.hpp
@@ -3,6 +3,7 @@
 
 // system includes
 #include <string>
+#include <optional>
 
 // other includes
 #include "boost/hana.hpp"

--- a/src/ENDFtk/file/Base.hpp
+++ b/src/ENDFtk/file/Base.hpp
@@ -2,6 +2,7 @@
 #define NJOY_ENDFTK_FILE_BASE
 
 // system includes
+#include <optional>
 
 // other includes
 #include "boost/hana.hpp"

--- a/src/ENDFtk/section/1/458.hpp
+++ b/src/ENDFtk/section/1/458.hpp
@@ -3,6 +3,7 @@
 
 // system includes
 #include <variant>
+#include <optional>
 
 // other includes
 #include "ENDFtk/types.hpp"

--- a/src/ENDFtk/section/12.hpp
+++ b/src/ENDFtk/section/12.hpp
@@ -3,6 +3,7 @@
 
 // system includes
 #include <variant>
+#include <optional>
 
 // other includes
 #include "range/v3/view/chunk.hpp"

--- a/src/ENDFtk/section/13.hpp
+++ b/src/ENDFtk/section/13.hpp
@@ -2,6 +2,7 @@
 #define NJOY_ENDFTK_SECTION_13
 
 // system includes
+#include <optional>
 
 // other includes
 #include "ENDFtk/ControlRecord.hpp"

--- a/src/ENDFtk/section/2/151.hpp
+++ b/src/ENDFtk/section/2/151.hpp
@@ -4,6 +4,7 @@
 // system includes
 #include <complex>
 #include <variant>
+#include <optional>
 
 // other includes
 #include "range/v3/algorithm/count.hpp"

--- a/src/ENDFtk/section/7/4.hpp
+++ b/src/ENDFtk/section/7/4.hpp
@@ -4,6 +4,7 @@
 // system includes
 #include <variant>
 #include <vector>
+#include <optional>
 
 // other includes
 #include "boost/hana.hpp"

--- a/src/ENDFtk/section/8/457.hpp
+++ b/src/ENDFtk/section/8/457.hpp
@@ -2,6 +2,7 @@
 #define NJOY_ENDFTK_SECTION_8_457
 
 // system includes
+#include <optional>
 
 // other includes
 #include "range/v3/action/join.hpp"


### PR DESCRIPTION
This merges directly into master to enable the scheduled runs.

With these changes, the entire CI workflow should now run once every day. This will allow us to detect the issue we recently saw concerning the missing optional includes.