### PR TITLE
Added kps to constructors in MF2 MT151 (seems to have been an omission)

### DIFF
--- a/python/src/section/2/151/ResonanceChannels.python.cpp
+++ b/python/src/section/2/151/ResonanceChannels.python.cpp
@@ -34,10 +34,11 @@ void wrapResonanceChannels( python::module& module, python::module& ) {
                   std::vector< unsigned int >&&,
                   std::vector< double >&&, std::vector< double >&&,
                   std::vector< double >&&, std::vector< double >&&,
-                  int >(),
+                  int, int >(),
     python::arg( "spin" ), python::arg( "parity" ), python::arg( "ppi" ),
     python::arg( "l" ), python::arg( "s" ), python::arg( "b" ),
     python::arg( "apt" ), python::arg( "ape" ), python::arg( "kbk" ) = 0,
+    python::arg( "kps" ) = 0,
     "Initialise the component\n\n"
     "Arguments:\n"
     "    self      the component\n"
@@ -50,17 +51,18 @@ void wrapResonanceChannels( python::module& module, python::module& ) {
     "              of the penetrability and the shift factor (NCH values)\n"
     "    ape       the true scattering radius values for the calculation\n"
     "              of the phase shift (NCH values)\n"
-    "    kbk       the number of channels with a background R-matrix"
+    "    kbk       the number of channels with a background R-matrix\n"
+    "    kps       the phase shift option"
   )
   .def(
 
     python::init< double, double, std::vector< unsigned int >&&,
                   std::vector< unsigned int >&&,
                   std::vector< double >&&, std::vector< double >&&,
-                  std::vector< double >&& >(),
+                  std::vector< double >&&, int, int >(),
     python::arg( "spin" ), python::arg( "parity" ), python::arg( "ppi" ),
     python::arg( "l" ), python::arg( "s" ), python::arg( "b" ),
-    python::arg( "ap" ),
+    python::arg( "ap" ), python::arg( "kbk" ) = 0, python::arg( "kps" ) = 0,
     "Initialise the component\n\n"
     "Arguments:\n"
     "    self      the component\n"
@@ -69,7 +71,9 @@ void wrapResonanceChannels( python::module& module, python::module& ) {
     "    l         the orbital momentum values (NCH values)\n"
     "    s         the channel spin values (NCH values)\n"
     "    b         the boundary condition values (NCH values)\n"
-    "    ap        the scattering radius values (NCH values)"
+    "    ap        the scattering radius values (NCH values)\n"
+    "    kbk       the number of channels with a background R-matrix\n"
+    "    kps       the phase shift option"
   )
   .def_property_readonly(
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited/ResonanceChannels/src/ctor.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/ResonanceChannels/src/ctor.hpp
@@ -23,6 +23,7 @@ public:
  *  @param[in] ape      the true scattering radius values for the calculation
  *                      of the phase shift (NCH values)
  *  @param[in] kbk      the number of channels with a background R-matrix
+ *  @param[in] kps      the phase shift option
  */
 ResonanceChannels( double spin, double parity,
                    std::vector< unsigned int >&& ppi,
@@ -31,9 +32,10 @@ ResonanceChannels( double spin, double parity,
                    std::vector< double >&& b,
                    std::vector< double >&& apt,
                    std::vector< double >&& ape,
-                   int kbk = 0 )
+                   int kbk = 0,
+                   int kps = 0 )
   try : ResonanceChannels(
-          ListRecord( spin, parity, kbk, 0, l.size(),
+          ListRecord( spin, parity, kbk, kps, l.size(),
                       generateList( std::move( ppi ),
                                     std::move( l ),
                                     std::move( s ),
@@ -57,15 +59,19 @@ ResonanceChannels( double spin, double parity,
  *  @param[in] s        the channel spin values (NCH values)
  *  @param[in] b        the boundary condition values (NCH values)
  *  @param[in] ap       the scattering radius values (NCH values)
+ *  @param[in] kbk      the number of channels with a background R-matrix
+ *  @param[in] kps      the phase shift option
  */
 ResonanceChannels( double spin, double parity,
                    std::vector< unsigned int >&& ppi,
                    std::vector< unsigned int >&& l,
                    std::vector< double >&& s,
                    std::vector< double >&& b,
-                   std::vector< double >&& ap )
+                   std::vector< double >&& ap,
+                   int kbk = 0,
+                   int kps = 0 )
   try : ResonanceChannels(
-          ListRecord( spin, parity, 0, 0, l.size(),
+          ListRecord( spin, parity, kbk, kps, l.size(),
                       generateList( std::move( ppi ),
                                     std::move( l ),
                                     std::move( s ),


### PR DESCRIPTION
KBK and KPS are options that were added to MF2 MT151 but these changes were not entirely merged into the ENDFtk interface for MF2 MT151. The main issue was that KBK and KPS were not specified in all of the constructors for ResonanceChannels - even though the retrieval functions were specified.

This is a very minimal change and can be merged regardless of the state of the others PRs.