### PR TITLE
Corrected function for returning the competitive widths

### DIFF
--- a/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent/LValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent/LValue.hpp
@@ -183,7 +183,7 @@ public:
   /**
    *  @brief Return the average competitive width values.
    */
-  auto averageCompetitiveWidths() const { return this->GF(); }
+  auto averageCompetitiveWidths() const { return this->GX(); }
 
   using ListRecord::NC;
   using ListRecord::print;


### PR DESCRIPTION
The wrong function was used in the function to return the competitive widths (it returned the fission ones).

This does not change anything since the competitive widths and fission widths are currently zero by default. Still, better to be consistent.