### PR TITLE
Wrapped python wrapper functions for MF2 into mf2 namespace

### DIFF
--- a/python/src/section/2/151.python.cpp
+++ b/python/src/section/2/151.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 // declarations - components
 void wrapScatteringRadius( python::module&, python::module& );
 void wrapSpecialCase( python::module&, python::module& );
@@ -39,6 +41,8 @@ void wrapUnresolvedEnergyDependent( python::module&, python::module& );
 void wrapResonanceRange( python::module&, python::module& );
 void wrapIsotope( python::module&, python::module& );
 
+} // namespace mf2
+
 void wrapSection_2_151( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -55,33 +59,33 @@ void wrapSection_2_151( python::module& module, python::module& viewmodule ) {
   );
 
   // wrap components
-  wrapScatteringRadius( submodule, viewmodule );
-  wrapSpecialCase( submodule, viewmodule );
-  wrapBreitWignerLValue( submodule, viewmodule );
-  wrapReichMooreLValue( submodule, viewmodule );
-  wrapSingleLevelBreitWigner( submodule, viewmodule );
-  wrapMultiLevelBreitWigner( submodule, viewmodule );
-  wrapReichMoore( submodule, viewmodule );
-  wrapParticlePairs( submodule, viewmodule );
-  wrapResonanceChannels( submodule, viewmodule );
-  wrapResonanceParameters( submodule, viewmodule );
-  wrapNoBackgroundRMatrix( submodule, viewmodule );
-  wrapSammyBackgroundRMatrix( submodule, viewmodule );
-  wrapFrohnerBackgroundRMatrix( submodule, viewmodule );
-  wrapTabulatedBackgroundRMatrix( submodule, viewmodule );
-  wrapBackgroundChannels( submodule, viewmodule );
-  wrapSpinGroup( submodule, viewmodule );
-  wrapRMatrixLimited( submodule, viewmodule );
-  wrapUnresolvedEnergyDependentFissionWidthsJValue( submodule, viewmodule );
-  wrapUnresolvedEnergyDependentJValue( submodule, viewmodule );
-  wrapUnresolvedEnergyIndependentLValue( submodule, viewmodule );
-  wrapUnresolvedEnergyDependentFissionWidthsLValue( submodule, viewmodule );
-  wrapUnresolvedEnergyDependentLValue( submodule, viewmodule );
-  wrapUnresolvedEnergyIndependent( submodule, viewmodule );
-  wrapUnresolvedEnergyDependentFissionWidths( submodule, viewmodule );
-  wrapUnresolvedEnergyDependent( submodule, viewmodule );
-  wrapResonanceRange( submodule, viewmodule );
-  wrapIsotope( submodule, viewmodule );
+  mf2::wrapScatteringRadius( submodule, viewmodule );
+  mf2::wrapSpecialCase( submodule, viewmodule );
+  mf2::wrapBreitWignerLValue( submodule, viewmodule );
+  mf2::wrapReichMooreLValue( submodule, viewmodule );
+  mf2::wrapSingleLevelBreitWigner( submodule, viewmodule );
+  mf2::wrapMultiLevelBreitWigner( submodule, viewmodule );
+  mf2::wrapReichMoore( submodule, viewmodule );
+  mf2::wrapParticlePairs( submodule, viewmodule );
+  mf2::wrapResonanceChannels( submodule, viewmodule );
+  mf2::wrapResonanceParameters( submodule, viewmodule );
+  mf2::wrapNoBackgroundRMatrix( submodule, viewmodule );
+  mf2::wrapSammyBackgroundRMatrix( submodule, viewmodule );
+  mf2::wrapFrohnerBackgroundRMatrix( submodule, viewmodule );
+  mf2::wrapTabulatedBackgroundRMatrix( submodule, viewmodule );
+  mf2::wrapBackgroundChannels( submodule, viewmodule );
+  mf2::wrapSpinGroup( submodule, viewmodule );
+  mf2::wrapRMatrixLimited( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyDependentFissionWidthsJValue( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyDependentJValue( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyIndependentLValue( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyDependentFissionWidthsLValue( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyDependentLValue( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyIndependent( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyDependentFissionWidths( submodule, viewmodule );
+  mf2::wrapUnresolvedEnergyDependent( submodule, viewmodule );
+  mf2::wrapResonanceRange( submodule, viewmodule );
+  mf2::wrapIsotope( submodule, viewmodule );
 
   // wrap views created by this section
   // none of these are supposed to be created directly by the user

--- a/python/src/section/2/151/BackgroundChannels.python.cpp
+++ b/python/src/section/2/151/BackgroundChannels.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapBackgroundChannels( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -109,3 +111,5 @@ void wrapBackgroundChannels( python::module& module, python::module& viewmodule 
   // no standard definitions - read constructor needs number of channels and
   // number of background matrices
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/BreitWignerLValue.python.cpp
+++ b/python/src/section/2/151/BreitWignerLValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapBreitWignerLValue( python::module& module, python::module& ) {
 
   // type aliases
@@ -215,3 +217,5 @@ void wrapBreitWignerLValue( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/FrohnerBackgroundRMatrix.python.cpp
+++ b/python/src/section/2/151/FrohnerBackgroundRMatrix.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapFrohnerBackgroundRMatrix( python::module& module, python::module& ) {
 
   // type aliases
@@ -101,3 +103,5 @@ void wrapFrohnerBackgroundRMatrix( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/Isotope.python.cpp
+++ b/python/src/section/2/151/Isotope.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapIsotope( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -100,3 +102,5 @@ void wrapIsotope( python::module& module, python::module& viewmodule ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/MultiLevelBreitWigner.python.cpp
+++ b/python/src/section/2/151/MultiLevelBreitWigner.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapMultiLevelBreitWigner( python::module& module, python::module& ) {
 
   // type aliases
@@ -126,3 +128,5 @@ void wrapMultiLevelBreitWigner( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/NoBackgroundRMatrix.python.cpp
+++ b/python/src/section/2/151/NoBackgroundRMatrix.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapNoBackgroundRMatrix( python::module& module, python::module& ) {
 
   // type aliases
@@ -65,3 +67,5 @@ void wrapNoBackgroundRMatrix( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ParticlePairs.python.cpp
+++ b/python/src/section/2/151/ParticlePairs.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapParticlePairs( python::module& module, python::module& ) {
 
   // type aliases
@@ -228,3 +230,5 @@ void wrapParticlePairs( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/RMatrixLimited.python.cpp
+++ b/python/src/section/2/151/RMatrixLimited.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapRMatrixLimited( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -178,3 +180,5 @@ void wrapRMatrixLimited( python::module& module, python::module& viewmodule ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ReichMoore.python.cpp
+++ b/python/src/section/2/151/ReichMoore.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapReichMoore( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -156,3 +158,5 @@ void wrapReichMoore( python::module& module, python::module& viewmodule ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ReichMooreLValue.python.cpp
+++ b/python/src/section/2/151/ReichMooreLValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapReichMooreLValue( python::module& module, python::module& ) {
 
   // type aliases
@@ -187,3 +189,5 @@ void wrapReichMooreLValue( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ResonanceChannels.python.cpp
+++ b/python/src/section/2/151/ResonanceChannels.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapResonanceChannels( python::module& module, python::module& ) {
 
   // type aliases
@@ -225,3 +227,5 @@ void wrapResonanceChannels( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ResonanceParameters.python.cpp
+++ b/python/src/section/2/151/ResonanceParameters.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapResonanceParameters( python::module& module, python::module& ) {
 
   // type aliases
@@ -95,3 +97,5 @@ void wrapResonanceParameters( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ResonanceRange.python.cpp
+++ b/python/src/section/2/151/ResonanceRange.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapResonanceRange( python::module& module, python::module& ) {
 
   // type aliases
@@ -152,3 +154,5 @@ void wrapResonanceRange( python::module& module, python::module& ) {
     "The number of lines in this component"
   );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/SammyBackgroundRMatrix.python.cpp
+++ b/python/src/section/2/151/SammyBackgroundRMatrix.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapSammyBackgroundRMatrix( python::module& module, python::module& ) {
 
   // type aliases
@@ -117,3 +119,5 @@ void wrapSammyBackgroundRMatrix( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/ScatteringRadius.python.cpp
+++ b/python/src/section/2/151/ScatteringRadius.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapScatteringRadius( python::module& module, python::module& ) {
 
   // type aliases
@@ -77,3 +79,5 @@ void wrapScatteringRadius( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/SingleLevelBreitWigner.python.cpp
+++ b/python/src/section/2/151/SingleLevelBreitWigner.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapSingleLevelBreitWigner( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -128,3 +130,5 @@ void wrapSingleLevelBreitWigner( python::module& module, python::module& viewmod
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/SpecialCase.python.cpp
+++ b/python/src/section/2/151/SpecialCase.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapSpecialCase( python::module& module, python::module& ) {
 
   // type aliases
@@ -102,3 +104,5 @@ void wrapSpecialCase( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/SpinGroup.python.cpp
+++ b/python/src/section/2/151/SpinGroup.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapSpinGroup( python::module& module, python::module& ) {
 
   // type aliases
@@ -145,3 +147,5 @@ void wrapSpinGroup( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/TabulatedBackgroundRMatrix.python.cpp
+++ b/python/src/section/2/151/TabulatedBackgroundRMatrix.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapTabulatedBackgroundRMatrix( python::module& module, python::module& ) {
 
   // type aliases
@@ -153,3 +155,5 @@ void wrapTabulatedBackgroundRMatrix( python::module& module, python::module& ) {
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyDependent.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyDependent.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyDependent( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -143,3 +145,5 @@ void wrapUnresolvedEnergyDependent( python::module& module, python::module& view
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyDependentFissionWidths.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyDependentFissionWidths.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyDependentFissionWidths( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -165,3 +167,5 @@ void wrapUnresolvedEnergyDependentFissionWidths( python::module& module, python:
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyDependentFissionWidthsJValue.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyDependentFissionWidthsJValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyDependentFissionWidthsJValue( python::module& module, python::module& ) {
 
   // type aliases
@@ -219,3 +221,5 @@ void wrapUnresolvedEnergyDependentFissionWidthsJValue( python::module& module, p
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyDependentFissionWidthsLValue.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyDependentFissionWidthsLValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyDependentFissionWidthsLValue( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -94,3 +96,5 @@ void wrapUnresolvedEnergyDependentFissionWidthsLValue( python::module& module, p
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyDependentJValue.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyDependentJValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyDependentJValue( python::module& module, python::module& ) {
 
   // type aliases
@@ -237,3 +239,5 @@ void wrapUnresolvedEnergyDependentJValue( python::module& module, python::module
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyDependentLValue.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyDependentLValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyDependentLValue( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -94,3 +96,5 @@ void wrapUnresolvedEnergyDependentLValue( python::module& module, python::module
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyIndependent.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyIndependent.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyIndependent( python::module& module, python::module& viewmodule ) {
 
   // type aliases
@@ -143,3 +145,5 @@ void wrapUnresolvedEnergyIndependent( python::module& module, python::module& vi
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2

--- a/python/src/section/2/151/UnresolvedEnergyIndependentLValue.python.cpp
+++ b/python/src/section/2/151/UnresolvedEnergyIndependentLValue.python.cpp
@@ -10,6 +10,8 @@
 // namespace aliases
 namespace python = pybind11;
 
+namespace mf2 {
+
 void wrapUnresolvedEnergyIndependentLValue( python::module& module, python::module& ) {
 
   // type aliases
@@ -229,3 +231,5 @@ void wrapUnresolvedEnergyIndependentLValue( python::module& module, python::modu
   // add standard component definitions
   addStandardComponentDefinitions< Component >( component );
 }
+
+} // namespace mf2


### PR DESCRIPTION
MF2 and MF32 use similar objects (also with a similar interface), e.g. the Resonanceparameters in MF2 LRF7 and MF32 LCOMP1 LRF7 and LCOMP2 LRF7. Such things happen quite often in the ENDF format (e.g. MF4 and MF14, MF6 and MF26, etc.).

Wrapper function name clashes occur in the linking process of the python bindings when a situation like this pops up. To solve this, wrapper function are now being wrapped into the appropriate namespaces associated to the proper file. Since MF2 was implemented long before this became standard practice, this section does not have this namespace wrapping.

In order to avoid future MF32 namespace conflicts, the PR puts all MF2 wrapper functions inside an mf2 namespace. This has no effect on the actual python interface so no tests were updated.