### PR TITLE
Updating GitHub actions config for CI

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         which ${{matrix.cxx}}
         ${{matrix.cxx}} --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: mkdir bin
       run: mkdir bin
     - name: cmake


### PR DESCRIPTION
Another simple one.

GitHub Actions issued deprecation warnings and this PR fixes that: just increasing the version of the checkout action from v2 to v3. Done.