### PR TITLE
Changing CI to use g++-10 to fix an issue in MacOS 11 

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-11 ]
-        cxx: [ clang++, g++-9 ]
+        cxx: [ clang++, g++-10 ]
         build_type: [ Debug, Release ]
 
     steps:


### PR DESCRIPTION
MacOS 11 runners no longer supports g++-9 so the CI now fails sicne it cannot find the compiler.