### PR TITLE
Feature/has section

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-11 ]
-        cxx: [ clang++, g++-9 ]
+        cxx: [ clang++, g++-10 ]
         build_type: [ Debug, Release ]
 
     steps:

--- a/python/src/Material.python.cpp
+++ b/python/src/Material.python.cpp
@@ -67,6 +67,27 @@ void wrapMaterial( python::module& module, python::module& viewmodule ) {
     "    self    the file\n"
     "    mf      the MF number of the file"
   )
+  .def(
+
+    "has_MF_MT",
+    &Material::hasMFMT,
+    "Return whether or not the material has a section with the given MF and MT "
+    "number\n\n"
+    "Arguments:\n"
+    "    self    the material\n"
+    "    mf      the MF number of the section\n"
+    "    mt      the MT number of the section"
+  )
+  .def(
+
+    "has_section",
+    &Material::hasSection,
+    "Return whether or not the material has a file with the given MF number\n\n"
+    "Arguments:\n"
+    "    self    the material\n"
+    "    mf      the MF number of the section\n"
+    "    mt      the MT number of the section"
+  )
   .def_property_readonly(
 
     "MFs",

--- a/python/src/tree/Material.python.cpp
+++ b/python/src/tree/Material.python.cpp
@@ -152,6 +152,30 @@ void wrapTreeMaterial( python::module& module, python::module& viewmodule ) {
   )
   .def(
 
+    "section",
+    python::overload_cast< int, int >( &Material::section, python::const_ ),
+    python::arg( "mf" ), python::arg( "mt" ),
+    "Return the section with the requested MF and MT number\n\n"
+    "Arguments:\n"
+    "    self    the ENDF tree material\n"
+    "    mf      the MF number of the section to be returned\n",
+    "    mt      the Mt number of the section to be returned",
+    python::return_value_policy::reference_internal
+  )
+  .def(
+
+    "MFMT",
+    python::overload_cast< int, int >( &Material::MFMT, python::const_ ),
+    python::arg( "mf" ), python::arg( "mt" ),
+    "Return the section with the requested MF and MT number\n\n"
+    "Arguments:\n"
+    "    self    the ENDF tree material\n"
+    "    mf      the MF number of the section to be returned\n",
+    "    mt      the Mt number of the section to be returned",
+    python::return_value_policy::reference_internal
+  )
+  .def(
+
     "parse",
     [] ( const Material& self ) -> ParsedMaterial {
 

--- a/python/src/tree/Material.python.cpp
+++ b/python/src/tree/Material.python.cpp
@@ -87,6 +87,27 @@ void wrapTreeMaterial( python::module& module, python::module& viewmodule ) {
     "    self    the material\n"
     "    mf      the MF number of the file"
   )
+  .def(
+
+    "has_MF_MT",
+    &Material::hasMFMT,
+    "Return whether or not the material has a section with the given MF and MT "
+    "number\n\n"
+    "Arguments:\n"
+    "    self    the material\n"
+    "    mf      the MF number of the section\n"
+    "    mt      the MT number of the section"
+  )
+  .def(
+
+    "has_section",
+    &Material::hasSection,
+    "Return whether or not the material has a file with the given MF number\n\n"
+    "Arguments:\n"
+    "    self    the material\n"
+    "    mf      the MF number of the section\n"
+    "    mt      the MT number of the section"
+  )
   .def_property_readonly(
 
     "file_numbers",

--- a/src/ENDFtk/Material.hpp
+++ b/src/ENDFtk/Material.hpp
@@ -150,6 +150,31 @@ namespace ENDFtk {
     }
 
     /**
+     *  @brief Return whether or not the material has a section with the given
+     *         MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section
+     *  @param[in]   mt   the MT number of the section
+     */
+    bool hasMFMT( int mf, int mt ) const {
+
+      return this->hasMF( mf )
+                 ? std::visit( [&] ( const auto& file ) -> bool
+                                   { return file.hasMT( mt ); },
+                               this->MF( mf ) )
+                 : false;
+    }
+
+    /**
+     *  @brief Return whether or not the material has a section with the given
+     *         MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section
+     *  @param[in]   mt   the MT number of the section
+     */
+    bool hasSection( int mf, int mt ) const { return this->hasMFMT( mf, mt ); }
+
+    /**
      *  @brief Return the file with the requested MF number
      *
      *  @param[in] mf   the MF number of the file to be returned

--- a/src/ENDFtk/Material/test/Material.test.cpp
+++ b/src/ENDFtk/Material/test/Material.test.cpp
@@ -1127,6 +1127,36 @@ void verifyMaterial( const Material& chunk ) {
   CHECK( chunk.hasFile( 5 ) );
   CHECK( not chunk.hasFile( 6 ) );
 
+  CHECK( chunk.hasMFMT( 1, 451 ) );
+  CHECK( not chunk.hasMFMT( 1, 452 ) );
+  CHECK( chunk.hasMFMT( 2, 151 ) );
+  CHECK( not chunk.hasMFMT( 2, 152 ) );
+  CHECK( chunk.hasMFMT( 3, 1 ) );
+  CHECK( chunk.hasMFMT( 3, 2 ) );
+  CHECK( chunk.hasMFMT( 3, 16 ) );
+  CHECK( not chunk.hasMFMT( 3, 102 ) );
+  CHECK( not chunk.hasMFMT( 4, 1 ) );
+  CHECK( chunk.hasMFMT( 4, 2 ) );
+  CHECK( chunk.hasMFMT( 4, 16 ) );
+  CHECK( not chunk.hasMFMT( 5, 1 ) );
+  CHECK( not chunk.hasMFMT( 5, 2 ) );
+  CHECK( chunk.hasMFMT( 5, 16 ) );
+
+  CHECK( chunk.hasSection( 1, 451 ) );
+  CHECK( not chunk.hasSection( 1, 452 ) );
+  CHECK( chunk.hasSection( 2, 151 ) );
+  CHECK( not chunk.hasSection( 2, 152 ) );
+  CHECK( chunk.hasSection( 3, 1 ) );
+  CHECK( chunk.hasSection( 3, 2 ) );
+  CHECK( chunk.hasSection( 3, 16 ) );
+  CHECK( not chunk.hasSection( 3, 102 ) );
+  CHECK( not chunk.hasSection( 4, 1 ) );
+  CHECK( chunk.hasSection( 4, 2 ) );
+  CHECK( chunk.hasSection( 4, 16 ) );
+  CHECK( not chunk.hasSection( 5, 1 ) );
+  CHECK( not chunk.hasSection( 5, 2 ) );
+  CHECK( chunk.hasSection( 5, 16 ) );
+
   decltype(auto) mf1 = std::get< file::Type< 1 > >( chunk.MF( 1 ) );
   CHECK( mf1.hasMT( 451 ) );
   CHECK( not mf1.hasMT( 452 ) );

--- a/src/ENDFtk/file/30.hpp
+++ b/src/ENDFtk/file/30.hpp
@@ -30,6 +30,20 @@ namespace file {
      */
     static constexpr int fileNumber() { return 30; }
 
+    /**
+     *  @brief Verify if a given section (defined by the MT number) is defined
+     *
+     *  @param mt   the MT number of the section to be verified
+     */
+    static constexpr bool hasMT( int ) { return false; }
+
+    /**
+     *  @brief Verify if a given section (defined by the MT number) is defined
+     *
+     *  @param mt   the MT number of the section to be verified
+     */
+    static constexpr int hasSection( int ) { return false; }
+
     using NotImplementedYet::MF;
     using NotImplementedYet::print;
   };

--- a/src/ENDFtk/section/26/ContinuumEnergyAngle.hpp
+++ b/src/ENDFtk/section/26/ContinuumEnergyAngle.hpp
@@ -4,7 +4,8 @@
  *
  *  The ContinuumEnergyAngle class is used to represent the continuum
  *  energy-angle law=1 data of MF26. It is similar to the MF6 law=1, but only
- *  supports the LANG=1 option (Legendre coefficients).
+ *  supports the LANG=1 option (Legendre coefficients). In addition, only NA=0
+ *  is allowed but we do not enforce that restriction.
  *
  *  See ENDF102, section 26.2.1 for more information.
  */

--- a/src/ENDFtk/section/26/DiscreteTwoBodyScattering.hpp
+++ b/src/ENDFtk/section/26/DiscreteTwoBodyScattering.hpp
@@ -2,12 +2,9 @@
  *  @class
  *  @brief Discrete two-body scattering data for secondary particles (LAW=2)
  *
- *  The DiscreteTwoBodyScattering class is used to represent the discrete
- *  two-body scattering law=2 data of MF6.
- *
- *  The ContinuumEnergyAngle class is used to represent the two-body angular
- *  distribution law=2 data of MF26. It is similar to the MF6 law=1, but only
- *  supports the LANG=1 option (Legendre coefficients).
+ *  The DiscreteTwoBodyScattering class is used to represent the two-body angular
+ *  distribution law=2 data of MF26. It is similar to the MF6 law=2, but only
+ *  supports the LANG=11 to 15 options.
  *
  *  See ENDF102, section 26.2.2 for more information.
  */

--- a/src/ENDFtk/section/26/src/ctor.hpp
+++ b/src/ENDFtk/section/26/src/ctor.hpp
@@ -1,3 +1,11 @@
+//! @todo pybind11 variant needs default constructor workaround
+#ifdef PYBIND11
+/**
+ *  @brief Default constructor - only enabled for pybind11
+ */
+Type() = default;
+#endif
+
 /**
  *  @brief Constructor
  *

--- a/src/ENDFtk/section/6/DiscreteTwoBodyScattering/test/DiscreteTwoBodyScattering.test.cpp
+++ b/src/ENDFtk/section/6/DiscreteTwoBodyScattering/test/DiscreteTwoBodyScattering.test.cpp
@@ -48,7 +48,7 @@ SCENARIO( "DiscreteTwoBodyScattering" ) {
 
         std::string buffer;
         auto output = std::back_inserter( buffer );
-        chunk.print( output, 9228, 26, 5 );
+        chunk.print( output, 9228, 6, 5 );
         CHECK( buffer == string );
       } // THEN
     } // WHEN
@@ -59,7 +59,7 @@ SCENARIO( "DiscreteTwoBodyScattering" ) {
       auto end = string.end();
       long lineNumber = 1;
 
-      DiscreteTwoBodyScattering chunk( begin, end, lineNumber, 9228, 26, 5 );
+      DiscreteTwoBodyScattering chunk( begin, end, lineNumber, 9228, 6, 5 );
 
       THEN( "a DiscreteTwoBodyScattering can "
             "be constructed and members can be tested" ) {
@@ -71,7 +71,7 @@ SCENARIO( "DiscreteTwoBodyScattering" ) {
 
         std::string buffer;
         auto output = std::back_inserter( buffer );
-        chunk.print( output, 9228, 26, 5 );
+        chunk.print( output, 9228, 6, 5 );
         CHECK( buffer == string );
       } // THEN
     } // WHEN
@@ -136,7 +136,7 @@ SCENARIO( "DiscreteTwoBodyScattering" ) {
       THEN( "an exception is thrown upon construction" ) {
 
         CHECK_THROWS( DiscreteTwoBodyScattering( begin, end, lineNumber,
-                                                 9228, 26, 5 ) );
+                                                 9228, 6, 5 ) );
       } // THEN
     } // WHEN
   } // GIVEN
@@ -144,12 +144,12 @@ SCENARIO( "DiscreteTwoBodyScattering" ) {
 
 std::string chunk() {
   return
-    " 0.000000+0 0.000000+0          0          0          1          2922826  5     \n"
-    "          2          1                                            922826  5     \n"
-    " 0.000000+0 1.000000-5          0          0          4          4922826  5     \n"
-    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0                      922826  5     \n"
-    " 0.000000+0 2.000000+7         12          0          6          3922826  5     \n"
-    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0 5.000000+0 6.000000+0922826  5     \n";
+    " 0.000000+0 0.000000+0          0          0          1          29228 6  5     \n"
+    "          2          1                                            9228 6  5     \n"
+    " 0.000000+0 1.000000-5          0          0          4          49228 6  5     \n"
+    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0                      9228 6  5     \n"
+    " 0.000000+0 2.000000+7         12          0          6          39228 6  5     \n"
+    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0 5.000000+0 6.000000+09228 6  5     \n";
 }
 
 void verifyChunk( const DiscreteTwoBodyScattering& chunk ) {
@@ -216,10 +216,10 @@ void verifyChunk( const DiscreteTwoBodyScattering& chunk ) {
 
 std::string invalidLANG() {
   return
-    " 0.000000+0 0.000000+0          0          0          1          2922826  5     \n"
-    "          2          1                                            922826  5     \n"
-    " 0.000000+0 1.000000-5          1          0          4          4922826  5     \n"
-    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0                      922826  5     \n"
-    " 0.000000+0 2.000000+7         12          0          6          3922826  5     \n"
-    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0 5.000000+0 6.000000+0922826  5     \n";
+    " 0.000000+0 0.000000+0          0          0          1          29228 6  5     \n"
+    "          2          1                                            9228 6  5     \n"
+    " 0.000000+0 1.000000-5          1          0          4          49228 6  5     \n"
+    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0                      9228 6  5     \n"
+    " 0.000000+0 2.000000+7         12          0          6          39228 6  5     \n"
+    " 1.000000+0 2.000000+0 3.000000+0 4.000000+0 5.000000+0 6.000000+09228 6  5     \n";
 }

--- a/src/ENDFtk/tree/File.hpp
+++ b/src/ENDFtk/tree/File.hpp
@@ -79,6 +79,13 @@ namespace tree {
     const Section& MT( int mt ) const { return this->section( mt ); }
 
     /**
+     *  @brief Return the section with the requested MT number
+     *
+     *  @param[in]   mt   the MT number of the section to be returned
+     */
+    Section& MT( int mt ) { return this->section( mt ); }
+
+    /**
      *  @brief Return whether or not the file has a section with the given MT
      *         number
      *

--- a/src/ENDFtk/tree/File/src/section.hpp
+++ b/src/ENDFtk/tree/File/src/section.hpp
@@ -17,3 +17,14 @@ const Section& section( int mt ) const {
     throw error;
   }
 }
+
+/**
+ *  @brief Return the section with the requested MT number
+ *
+ *  @param[in]   mt   the MF number of the section to be returned
+ */
+Section& section( int mt ) {
+
+  return const_cast< Section& >
+         ( const_cast< const File& >( *this ).section( mt ) );
+}

--- a/src/ENDFtk/tree/Material.hpp
+++ b/src/ENDFtk/tree/Material.hpp
@@ -62,16 +62,60 @@ namespace tree {
     /**
      *  @brief Return the file with the requested MF number
      *
-     *  @param[in]   mf   the MF number of the material to be returned
+     *  @param[in]   mf   the MF number of the file to be returned
      */
     const File& MF( int mf ) const { return this->file( mf ); }
 
     /**
      *  @brief Return the file with the requested MF number
      *
-     *  @param[in]   mf   the MF number of the material to be returned
+     *  @param[in]   mf   the MF number of the file to be returned
      */
     File& MF( int mf ) { return this->file( mf ); }
+
+    /**
+     *  @brief Return the section with the requested MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section to be returned
+     *  @param[in]   mt   the MT number of the section to be returned
+     */
+    const Section& section( int mf, int mt ) const {
+
+      return this->file( mf ).section( mt );
+    }
+
+    /**
+     *  @brief Return the section with the requested MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section to be returned
+     *  @param[in]   mt   the MT number of the section to be returned
+     */
+    Section& section( int mf, int mt ) { 
+
+      return this->file( mf ).section( mt );
+    }
+
+    /**
+     *  @brief Return the section with the requested MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section to be returned
+     *  @param[in]   mt   the MT number of the section to be returned
+     */
+    const Section& MFMT( int mf, int mt ) const {
+
+      return this->section( mf, mt );
+    }
+
+    /**
+     *  @brief Return the section with the requested MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section to be returned
+     *  @param[in]   mt   the MT number of the section to be returned
+     */
+    Section& MFMT( int mf, int mt ) {
+
+      return this->section( mf, mt );
+    }
 
     /**
      *  @brief Return whether or not the material has a file with the given MF

--- a/src/ENDFtk/tree/Material.hpp
+++ b/src/ENDFtk/tree/Material.hpp
@@ -90,6 +90,27 @@ namespace tree {
     bool hasFile( int mf ) const { return this->hasMF( mf ); }
 
     /**
+     *  @brief Return whether or not the material has a section with the given
+     *         MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section
+     *  @param[in]   mt   the MT number of the section
+     */
+    bool hasMFMT( int mf, int mt ) const {
+
+      return this->hasMF( mf ) ? this->file( mf ).hasMT( mt ) : false;
+    }
+
+    /**
+     *  @brief Return whether or not the material has a section with the given
+     *         MF and MT number
+     *
+     *  @param[in]   mf   the MF number of the section
+     *  @param[in]   mt   the MT number of the section
+     */
+    bool hasSection( int mf, int mt ) const { return this->hasMFMT( mf, mt ); }
+
+    /**
      *  @brief Return all files in the material
      */
     auto files() const { return this->files_ | ranges::cpp20::views::values; }

--- a/src/ENDFtk/tree/Material/src/file.hpp
+++ b/src/ENDFtk/tree/Material/src/file.hpp
@@ -1,7 +1,7 @@
 /**
  *  @brief Return the file with the requested MF number
  *
- *  @param[in]   mf   the MF number of the material to be returned
+ *  @param[in]   mf   the MF number of the file to be returned
  */
 const File& file( int mf ) const {
 
@@ -24,7 +24,7 @@ const File& file( int mf ) const {
 /**
  *  @brief Return the file with the requested MF number
  *
- *  @param[in]   mf   the MF number of the material to be returned
+ *  @param[in]   mf   the MF number of the file to be returned
  */
 File& file( int mf ) {
 

--- a/src/ENDFtk/tree/Material/test/Material.test.cpp
+++ b/src/ENDFtk/tree/Material/test/Material.test.cpp
@@ -75,20 +75,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -146,20 +156,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -221,20 +241,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -295,20 +325,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -367,20 +407,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( true == material.file( 3 ).hasSection( 102 ) );
         CHECK( true == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( true == material.hasSection( 3, 102 ) );
+        CHECK( true == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -427,20 +477,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( true == material.file( 3 ).hasSection( 102 ) );
         CHECK( true == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( true == material.hasSection( 3, 102 ) );
+        CHECK( true == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -479,20 +539,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -534,20 +604,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -556,6 +636,8 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 6 ) );
         CHECK( true == material.file( 6 ).hasSection( 5 ) );
         CHECK( true == material.MF( 6 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 6, 5 ) );
+        CHECK( true == material.hasMFMT( 6, 5 ) );
 
         auto fileNumbers = material.fileNumbers();
         CHECK( 5 == material.size() );
@@ -602,20 +684,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );
@@ -624,6 +716,8 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 6 ) );
         CHECK( true == material.file( 6 ).hasSection( 5 ) );
         CHECK( true == material.MF( 6 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 6, 5 ) );
+        CHECK( true == material.hasMFMT( 6, 5 ) );
 
         auto fileNumbers = material.fileNumbers();
         CHECK( 5 == material.size() );
@@ -659,20 +753,30 @@ SCENARIO( "tree::Material" ) {
         CHECK( true == material.hasMF( 2 ) );
         CHECK( true == material.file( 2 ).hasSection( 151 ) );
         CHECK( true == material.MF( 2 ).hasMT( 151 ) );
+        CHECK( true == material.hasSection( 2, 151 ) );
+        CHECK( true == material.hasMFMT( 2, 151 ) );
 
         CHECK( true == material.hasFile( 3 ) );
         CHECK( true == material.hasMF( 3 ) );
         CHECK( true == material.file( 3 ).hasSection( 1 ) );
         CHECK( true == material.MF( 3 ).hasMT( 1 ) );
+        CHECK( true == material.hasSection( 3, 1 ) );
+        CHECK( true == material.hasMFMT( 3, 1 ) );
         CHECK( true == material.file( 3 ).hasSection( 5 ) );
         CHECK( true == material.MF( 3 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 3, 5 ) );
+        CHECK( true == material.hasMFMT( 3, 5 ) );
         CHECK( false == material.file( 3 ).hasSection( 102 ) );
         CHECK( false == material.MF( 3 ).hasMT( 102 ) );
+        CHECK( false == material.hasSection( 3, 102 ) );
+        CHECK( false == material.hasMFMT( 3, 102 ) );
 
         CHECK( true == material.hasFile( 4 ) );
         CHECK( true == material.hasMF( 4 ) );
         CHECK( true == material.file( 4 ).hasSection( 5 ) );
         CHECK( true == material.MF( 4 ).hasMT( 5 ) );
+        CHECK( true == material.hasSection( 4, 5 ) );
+        CHECK( true == material.hasMFMT( 4, 5 ) );
 
         CHECK( false == material.hasFile( 5 ) );
         CHECK( false == material.hasMF( 5 ) );


### PR DESCRIPTION
This extends the tree and parsed material object interface by adding a has_mf_mt and has_section function that takes both the MF and MT number of a section.

Also adds a section(mf,mt) function that returns a Section object on the tree Material. Adding this to a parsed Material is slightly more complicated so I'll wait to add it.