### PR TITLE
Feature/mf3 convenience

### DIFF
--- a/python/src/section/10/ReactionProduct.python.cpp
+++ b/python/src/section/10/ReactionProduct.python.cpp
@@ -52,6 +52,26 @@ void wrapReactionProduct( python::module& module, python::module& ) {
     "    energies       the energy values\n"
     "    xs             the cross section values"
   )
+  .def(
+
+    python::init< double, double, int, int,
+                  std::vector< double >&&, std::vector< double >&&,
+                  long >(),
+    python::arg( "qm" ), python::arg( "qi" ),
+    python::arg( "izap" ), python::arg( "lfs" ),
+    python::arg( "energies" ), python::arg( "xs" ),
+    python::arg( "interpolant" ) = 2,
+    "Initialise the component\n\n"
+    "Arguments:\n"
+    "    self          the component\n"
+    "    qm            the mass difference Q value\n"
+    "    qi            the reaction Q value\n"
+    "    izap          the za identifier of the product\n"
+    "    lfs           the excited level number\n"
+    "    energies      the energy values\n"
+    "    xs            the cross section values\n"
+    "    interpolant   the interpolation type (default 2 - linlin)"
+  )
   .def_property_readonly(
 
     "QM",

--- a/python/src/section/3.python.cpp
+++ b/python/src/section/3.python.cpp
@@ -50,6 +50,28 @@ void wrapSection_3( python::module& module, python::module& ) {
     "    energies       the energy values\n"
     "    xs             the cross section values"
   )
+  .def(
+
+    python::init< int, double, double, double, double,
+                  std::vector< double >&&, std::vector< double >&&,
+                  long, long >(),
+    python::arg( "mt" ), python::arg( "zaid" ), python::arg( "awr" ),
+    python::arg( "qm" ), python::arg( "qi" ),
+    python::arg( "energies" ), python::arg( "xs" ),
+    python::arg( "interpolant" ) = 2, python::arg( "lr" ) = 0,
+    "Initialise the section\n\n"
+    "Arguments:\n"
+    "    self          the section\n"
+    "    mt            the MT number\n"
+    "    zaid          the ZA  identifier\n"
+    "    awr           the atomic mass ratio\n"
+    "    qm            the mass difference Q value\n"
+    "    qi            the reaction Q value\n"
+    "    energies      the energy values\n"
+    "    xs            the cross section values\n"
+    "    interpolant   the interpolation type (default 2 - linlin)\n"
+    "    lr            the complex breakup flag (default 0)"
+  )
   .def_property_readonly(
 
     "QM",

--- a/python/src/section/9/ReactionProduct.python.cpp
+++ b/python/src/section/9/ReactionProduct.python.cpp
@@ -51,6 +51,26 @@ void wrapReactionProduct( python::module& module, python::module& ) {
     "    energies         the energy values\n"
     "    multiplicities   the multiplicity values"
   )
+  .def(
+
+    python::init< double, double, int, int,
+                  std::vector< double >&&, std::vector< double >&&,
+                  long >(),
+    python::arg( "qm" ), python::arg( "qi" ),
+    python::arg( "izap" ), python::arg( "lfs" ),
+    python::arg( "energies" ), python::arg( "multiplicities" ),
+    python::arg( "interpolant" ) = 2,
+    "Initialise the component\n\n"
+    "Arguments:\n"
+    "    self             the component\n"
+    "    qm               the mass difference Q value\n"
+    "    qi               the reaction Q value\n"
+    "    izap             the za identifier of the product\n"
+    "    lfs              the excited level number\n"
+    "    energies         the energy values\n"
+    "    multiplicities   the multiplicity values\n"
+    "    interpolants     the interpolation type (default 2 - linlin)"
+  )
   .def_property_readonly(
 
     "QM",

--- a/python/test/Test_ENDFtk_MF10_ReactionProduct.py
+++ b/python/test/Test_ENDFtk_MF10_ReactionProduct.py
@@ -57,11 +57,20 @@ class Test_ENDFtk_MF10_ReactionProduct( unittest.TestCase ) :
 
         # the data is given explicitly
         chunk = ReactionProduct( qm = 2.224648e+6, qi = 3.224648e+6,
-                                        izap = 95242, lfs = 2,
-                                        boundaries = [ 2 ],
-                                        interpolants = [ 5 ],
-                                        energies = [ 1., 3. ],
-                                        xs = [ 2., 4. ] )
+                                 izap = 95242, lfs = 2,
+                                 boundaries = [ 2 ],
+                                 interpolants = [ 5 ],
+                                 energies = [ 1., 3. ],
+                                 xs = [ 2., 4. ] )
+
+        verify_chunk( self, chunk )
+
+        # the data is given explicitly
+        chunk = ReactionProduct( qm = 2.224648e+6, qi = 3.224648e+6,
+                                 izap = 95242, lfs = 2,
+                                 energies = [ 1., 3. ],
+                                 xs = [ 2., 4. ],
+                                 interpolant = 5 )
 
         verify_chunk( self, chunk )
 

--- a/python/test/Test_ENDFtk_MF3_Section.py
+++ b/python/test/Test_ENDFtk_MF3_Section.py
@@ -16,6 +16,12 @@ class Test_ENDFtk_MF3_Section( unittest.TestCase ) :
               ' 1.000000-5 1.672869+1 2.000000-5 1.182897+1 7.500000+5 3.347392-5 125 3102     \n'
               ' 1.900000+7 2.751761-5 1.950000+7 2.731301-5 2.000000+7 2.710792-5 125 3102     \n' )
 
+    chunk_one_region = ( ' 1.001000+3 9.991673-1          0          0          0          0 125 3102     \n'
+                         ' 2.224648+6 3.224648+6          0          0          1          6 125 3102     \n'
+                         '          6          2                                             125 3102     \n'
+                         ' 1.000000-5 1.672869+1 2.000000-5 1.182897+1 7.500000+5 3.347392-5 125 3102     \n'
+                         ' 1.900000+7 2.751761-5 1.950000+7 2.731301-5 2.000000+7 2.710792-5 125 3102     \n' )
+
     valid_TPID = 'Just a tape identifier                                                          \n'
     valid_SEND = '                                                                   125 3  0     \n'
     valid_FEND = '                                                                   125 0  0     \n'
@@ -43,10 +49,10 @@ class Test_ENDFtk_MF3_Section( unittest.TestCase ) :
             self.assertEqual( 2, chunk.NR )
             self.assertEqual( 2, len( chunk.interpolants ) )
             self.assertEqual( 2, len( chunk.boundaries ) )
-            self.assertEqual( 5, chunk.interpolants[0] );
-            self.assertEqual( 2, chunk.interpolants[1] );
-            self.assertEqual( 3, chunk.boundaries[0] );
-            self.assertEqual( 6, chunk.boundaries[1] );
+            self.assertEqual( 5, chunk.interpolants[0] )
+            self.assertEqual( 2, chunk.interpolants[1] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( 6, chunk.boundaries[1] )
             self.assertEqual( 6, len( chunk.energies ) )
             self.assertEqual( 6, len( chunk.cross_sections ) )
             self.assertAlmostEqual( 1e-5, chunk.energies[0] )
@@ -68,6 +74,47 @@ class Test_ENDFtk_MF3_Section( unittest.TestCase ) :
             self.assertEqual( self.chunk + self.valid_SEND,
                               chunk.to_string( 125, 3 ) )
 
+        def verify_chunk_one_region( self, chunk ) :
+
+            # verify content
+            self.assertEqual( 102, chunk.MT )
+            self.assertEqual( 1001, chunk.ZA )
+            self.assertAlmostEqual( 0.9991673, chunk.AWR )
+            self.assertAlmostEqual( 0.9991673, chunk.atomic_weight_ratio )
+            self.assertEqual( 0, chunk.LR )
+            self.assertEqual( 0, chunk.complex_breakup )
+            self.assertAlmostEqual( 2.224648e+6, chunk.QM )
+            self.assertAlmostEqual( 2.224648e+6, chunk.mass_difference_qvalue )
+            self.assertAlmostEqual( 3.224648e+6, chunk.QI )
+            self.assertAlmostEqual( 3.224648e+6, chunk.reaction_qvalue )
+
+            self.assertEqual( 6, chunk.NP )
+            self.assertEqual( 1, chunk.NR )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 2, chunk.interpolants[0] )
+            self.assertEqual( 6, chunk.boundaries[0] )
+            self.assertEqual( 6, len( chunk.energies ) )
+            self.assertEqual( 6, len( chunk.cross_sections ) )
+            self.assertAlmostEqual( 1e-5, chunk.energies[0] )
+            self.assertAlmostEqual( 2e-5, chunk.energies[1] )
+            self.assertAlmostEqual( 7.5e+5, chunk.energies[2] )
+            self.assertAlmostEqual( 1.9e+7, chunk.energies[3] )
+            self.assertAlmostEqual( 1.95e+7, chunk.energies[4] )
+            self.assertAlmostEqual( 2e+7, chunk.energies[5] )
+            self.assertAlmostEqual( 1.672869e+1, chunk.cross_sections[0] )
+            self.assertAlmostEqual( 1.182897e+1, chunk.cross_sections[1] )
+            self.assertAlmostEqual( 3.347392e-5, chunk.cross_sections[2] )
+            self.assertAlmostEqual( 2.751761e-5, chunk.cross_sections[3] )
+            self.assertAlmostEqual( 2.731301e-5, chunk.cross_sections[4] )
+            self.assertAlmostEqual( 2.710792e-5, chunk.cross_sections[5] )
+
+            self.assertEqual( 5, chunk.NC )
+
+            # verify string
+            self.assertEqual( self.chunk_one_region + self.valid_SEND,
+                              chunk.to_string( 125, 3 ) )
+
         # the data is given explicitly
         chunk = Section( mt = 102,  zaid = 1001, lr = 0, awr = 0.9991673,
                          qm = 2.224648e+6, qi = 3.224648e+6,
@@ -83,6 +130,21 @@ class Test_ENDFtk_MF3_Section( unittest.TestCase ) :
         chunk = Section.from_string( self.chunk + self.valid_SEND )
 
         verify_chunk( self, chunk )
+
+        # the data is given explicitly
+        chunk = Section( mt = 102,  zaid = 1001, awr = 0.9991673,
+                         qm = 2.224648e+6, qi = 3.224648e+6,
+                         energies = [ 1e-5, 2e-5, 7.5e+5,
+                                      1.9e+7, 1.95e+7, 2e+7 ],
+                         xs = [ 1.672869e+1, 1.182897e+1, 3.347392e-5,
+                                2.751761e-5, 2.731301e-5, 2.710792e-5 ] )
+
+        verify_chunk_one_region( self, chunk )
+
+        # the data is read from a string
+        chunk = Section.from_string( self.chunk_one_region + self.valid_SEND )
+
+        verify_chunk_one_region( self, chunk )
 
         # the data is retrieved from a tree element and parsed
         tape = Tape.from_string( self.valid_TPID + self.chunk +

--- a/python/test/Test_ENDFtk_MF9_ReactionProduct.py
+++ b/python/test/Test_ENDFtk_MF9_ReactionProduct.py
@@ -65,6 +65,15 @@ class Test_ENDFtk_MF9_ReactionProduct( unittest.TestCase ) :
 
         verify_chunk( self, chunk )
 
+        # the data is given explicitly
+        chunk = ReactionProduct( qm = 2.224648e+6, qi = 3.224648e+6,
+                                 izap = 95242, lfs = 2,
+                                 energies = [ 1., 3. ],
+                                 multiplicities = [ 2., 4. ],
+                                 interpolant = 5 )
+
+        verify_chunk( self, chunk )
+
         # the data is read from a string
         chunk = ReactionProduct.from_string( self.chunk, 9534, 9, 102 )
 

--- a/src/ENDFtk/section/10/ReactionProduct/src/ctor.hpp
+++ b/src/ENDFtk/section/10/ReactionProduct/src/ctor.hpp
@@ -28,6 +28,25 @@ ReactionProduct( double qm, double qi, long izap, long lfs,
   }
 
 /**
+ *  @brief Constructor for a single interpolation zone
+ *
+ *  @param[in] qm             the mass difference Q value
+ *  @param[in] qi             the reaction Q value
+ *  @param[in] izap           the za identifier of the product
+ *  @param[in] lfs            the excited level number
+ *  @param[in] energies       the energy values
+ *  @param[in] xs             the multiplicities for every state
+ *  @param[in] interpolant    the interpolation type (default 2 - linlin)
+ */
+ReactionProduct( double qm, double qi, long izap, long lfs,
+                 std::vector< double >&& energies,
+                 std::vector< double >&& xs,
+                 long interpolant = 2 ) :
+  ReactionProduct( qm, qi, izap, lfs,
+                   { static_cast<long>( energies.size() ) }, { interpolant },
+                   std::move( energies ), std::move( xs ) ) {}
+
+/**
  *  @brief Constructor (from a buffer)
  *
  *  @tparam Iterator        a buffer iterator

--- a/src/ENDFtk/section/10/ReactionProduct/test/ReactionProduct.test.cpp
+++ b/src/ENDFtk/section/10/ReactionProduct/test/ReactionProduct.test.cpp
@@ -19,7 +19,7 @@ SCENARIO( "ReactionProduct" ) {
 
     std::string string = chunk();
 
-    WHEN( "the data is given explicitly" ) {
+    WHEN( "the data is given explicitly with boundaries and interpolants" ) {
 
       double qm = 2.224648e+6;
       double qi = 3.224648e+6;
@@ -35,6 +35,59 @@ SCENARIO( "ReactionProduct" ) {
                              std::move( interpolants ),
                              std::move( x ),
                              std::move( y ) );
+
+      THEN( "a ReactionProduct can be constructed and members can be "
+            "tested" ) {
+
+        verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 9534, 10, 102 );
+
+        CHECK( buffer == string );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is read from a string/stream" ) {
+
+      auto begin = string.begin();
+      auto end = string.end();
+      long lineNumber = 1;
+
+      ReactionProduct chunk( begin, end, lineNumber, 9534, 10, 102 );
+
+      THEN( "a ReactionProduct can be constructed and members can be "
+            "tested" ) {
+
+        verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 9534, 10, 102 );
+
+        CHECK( buffer == string );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is given explicitly with an interpolation type" ) {
+
+      double qm = 2.224648e+6;
+      double qi = 3.224648e+6;
+      long za = 95242;
+      long lfs = 2;
+      long interpolant = 5;
+      std::vector< double > x = { 1., 3. };
+      std::vector< double > y = { 2., 4. };
+
+      ReactionProduct chunk( qm, qi, za, lfs, std::move( x ), std::move( y ),
+                             interpolant );
 
       THEN( "a ReactionProduct can be constructed and members can be "
             "tested" ) {

--- a/src/ENDFtk/section/3/src/ctor.hpp
+++ b/src/ENDFtk/section/3/src/ctor.hpp
@@ -29,6 +29,26 @@ Type( int mt, double zaid, double awr, double qm, double qi, long lr,
          std::move( energies ), std::move( xs ) ) {}
 
 /**
+ *  @brief Constructor for a single interpolation zone
+ *
+ *  @param[in] mt             the MT number
+ *  @param[in] zaid           the ZA  identifier
+ *  @param[in] awr            the atomic mass ratio
+ *  @param[in] qm             the mass difference Q value
+ *  @param[in] qi             the reaction Q value
+ *  @param[in] energies       the energy values
+ *  @param[in] xs             the cross section values
+ *  @param[in] interpolant    the interpolation type (default 2 - linlin)
+ *  @param[in] lr             the complex breakup flag (default 0)
+ */
+Type( int mt, double zaid, double awr, double qm, double qi,
+      std::vector< double >&& energies, std::vector< double >&& xs,
+      long interpolant = 2, long lr = 0 ) :
+  Type( mt, zaid, awr, qm, qi, lr,
+        { static_cast<long>( energies.size() ) }, { interpolant },
+        std::move( energies ), std::move( xs ) ) {}
+
+/**
  *  @brief Constructor (from a buffer)
  *
  *  @tparam Iterator        a buffer iterator

--- a/src/ENDFtk/section/3/test/3.test.cpp
+++ b/src/ENDFtk/section/3/test/3.test.cpp
@@ -10,7 +10,9 @@
 using namespace njoy::ENDFtk;
 
 std::string chunk();
+std::string chunkWithOneZone();
 void verifyChunk( const section::Type< 3 >& );
+void verifyChunkWithOneZone( const section::Type< 3 >& );
 std::string validSEND();
 std::string invalidSEND();
 
@@ -40,10 +42,89 @@ SCENARIO( "section::Type< 3 >" ) {
                                 std::move( interpolants ),
                                 std::move( energies ), std::move( xs ) );
 
-      THEN( "a section::Type< 3 > can be constructed and "
-            "members can be tested" ) {
+      THEN( "a section::Type< 3 > can be constructed and members can be tested" ) {
 
         verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 125, 3 );
+
+        CHECK( buffer == sectionString );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is read from a string/stream with a valid SEND" ) {
+
+      auto begin = sectionString.begin();
+      auto end = sectionString.end();
+      long lineNumber = 0;
+      HeadRecord head( begin, end, lineNumber );
+
+      section::Type< 3 > chunk( head, begin, end, lineNumber, 125 );
+
+      THEN( "a section::Type< 3 > can be constructed and members can be tested" ) {
+
+        verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 125, 3 );
+
+        CHECK( buffer == sectionString );
+      } // THEN
+    } // WHEN
+
+    WHEN( "there is a tree::Section" ) {
+
+      tree::Section section( 125, 3, 102, std::string( sectionString ) );
+
+      section::Type< 3 > chunk = section.parse< 3 >();
+
+      THEN( "a section::Type< 3 > can be constructed and members can be tested" ) {
+
+        verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 125, 3 );
+
+        CHECK( buffer == sectionString );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "valid data for a section::Type< 3 > with a single interpolation region" ) {
+
+    std::string sectionString = chunkWithOneZone() + validSEND();
+
+    WHEN( "the data is given explicitly" ) {
+
+      int mt = 102;
+      int zaid = 1001;
+      double awr = 0.9991673;
+      double qm = 2.224648e+6;
+      double qi = 3.224648e+6;
+      std::vector< double > energies = { 1e-5, 2e-5, 7.5e+5,
+                                         1.9e+7, 1.95e+7, 2e+7 };
+      std::vector< double > xs = { 1.672869e+1, 1.182897e+1, 3.347392e-5,
+                                   2.751761e-5, 2.731301e-5, 2.710792e-5 };
+
+      section::Type< 3 > chunk( mt, zaid, awr, qm, qi,
+                                std::move( energies ), std::move( xs ) );
+
+      THEN( "a section::Type< 3 > can be constructed and  members can be tested" ) {
+
+        verifyChunkWithOneZone( chunk );
       } // THEN
 
       THEN( "it can be printed" ) {
@@ -68,7 +149,7 @@ SCENARIO( "section::Type< 3 >" ) {
       THEN( "a section::Type< 3 > can be constructed and "
             "members can be tested" ) {
 
-        verifyChunk( chunk );
+        verifyChunkWithOneZone( chunk );
       } // THEN
 
       THEN( "it can be printed" ) {
@@ -87,10 +168,9 @@ SCENARIO( "section::Type< 3 >" ) {
 
       section::Type< 3 > chunk = section.parse< 3 >();
 
-      THEN( "a section::Type< 3 > can be constructed and "
-            "members can be tested" ) {
+      THEN( "a section::Type< 3 > can be constructed and members can be tested" ) {
 
-        verifyChunk( chunk );
+        verifyChunkWithOneZone( chunk );
       } // THEN
 
       THEN( "it can be printed" ) {
@@ -154,6 +234,52 @@ void verifyChunk( const section::Type< 3 >& chunk ) {
   CHECK( 2 == chunk.interpolants()[1] );
   CHECK( 3 == chunk.boundaries()[0] );
   CHECK( 6 == chunk.boundaries()[1] );
+  CHECK( 6 == chunk.energies().size() );
+  CHECK( 6 == chunk.crossSections().size() );
+  CHECK( 1e-5 == Approx( chunk.energies()[0] ) );
+  CHECK( 2e-5 == Approx( chunk.energies()[1] ) );
+  CHECK( 7.5e+5 == Approx( chunk.energies()[2] ) );
+  CHECK( 1.9e+7 == Approx( chunk.energies()[3] ) );
+  CHECK( 1.95e+7 == Approx( chunk.energies()[4] ) );
+  CHECK( 2e+7 == Approx( chunk.energies()[5] ) );
+  CHECK( 1.672869e+1 == Approx( chunk.crossSections()[0] ) );
+  CHECK( 1.182897e+1 == Approx( chunk.crossSections()[1] ) );
+  CHECK( 3.347392e-5 == Approx( chunk.crossSections()[2] ) );
+  CHECK( 2.751761e-5 == Approx( chunk.crossSections()[3] ) );
+  CHECK( 2.731301e-5 == Approx( chunk.crossSections()[4] ) );
+  CHECK( 2.710792e-5 == Approx( chunk.crossSections()[5] ) );
+
+  CHECK( 5 == chunk.NC() );
+}
+
+std::string chunkWithOneZone(){
+  return
+    " 1.001000+3 9.991673-1          0          0          0          0 125 3102     \n"
+    " 2.224648+6 3.224648+6          0          0          1          6 125 3102     \n"
+    "          6          2                                             125 3102     \n"
+    " 1.000000-5 1.672869+1 2.000000-5 1.182897+1 7.500000+5 3.347392-5 125 3102     \n"
+    " 1.900000+7 2.751761-5 1.950000+7 2.731301-5 2.000000+7 2.710792-5 125 3102     \n";
+}
+
+void verifyChunkWithOneZone( const section::Type< 3 >& chunk ) {
+
+  CHECK( 102 == chunk.MT() );
+  CHECK( 1001 == chunk.ZA() );
+  CHECK( 0.9991673 == Approx( chunk.AWR() ) );
+  CHECK( 0.9991673 == Approx( chunk.atomicWeightRatio() ) );
+  CHECK( 0 == chunk.LR() );
+  CHECK( 0 == chunk.complexBreakUp() );
+  CHECK( 2.224648e+6 == Approx( chunk.QM() ) );
+  CHECK( 2.224648e+6 == Approx( chunk.massDifferenceQValue() ) );
+  CHECK( 3.224648e+6 == Approx( chunk.QI() ) );
+  CHECK( 3.224648e+6 == Approx( chunk.reactionQValue() ) );
+
+  CHECK( 6 == chunk.NP() );
+  CHECK( 1 == chunk.NR() );
+  CHECK( 1 == chunk.interpolants().size() );
+  CHECK( 1 == chunk.boundaries().size() );
+  CHECK( 2 == chunk.interpolants()[0] );
+  CHECK( 6 == chunk.boundaries()[0] );
   CHECK( 6 == chunk.energies().size() );
   CHECK( 6 == chunk.crossSections().size() );
   CHECK( 1e-5 == Approx( chunk.energies()[0] ) );

--- a/src/ENDFtk/section/9/ReactionProduct/src/ctor.hpp
+++ b/src/ENDFtk/section/9/ReactionProduct/src/ctor.hpp
@@ -28,6 +28,25 @@ ReactionProduct( double qm, double qi, long izap, long lfs,
   }
 
 /**
+ *  @brief Constructor for a single interpolation zone
+ *
+ *  @param[in] qm               the mass difference Q value
+ *  @param[in] qi               the reaction Q value
+ *  @param[in] izap             the za identifier of the product
+ *  @param[in] lfs              the excited level number
+ *  @param[in] energies         the energy values
+ *  @param[in] multiplicities   the multiplicities for every state
+ *  @param[in] interpolant      the interpolation type (default 2 - linlin)
+ */
+ReactionProduct( double qm, double qi, long izap, long lfs,
+                 std::vector< double >&& energies,
+                 std::vector< double >&& multiplicities,
+                 long interpolant = 2 ) :
+  ReactionProduct( qm, qi, izap, lfs,
+                   { static_cast<long>( energies.size() ) }, { interpolant },
+                   std::move( energies ), std::move( multiplicities ) ) {}
+
+/**
  *  @brief Constructor (from a buffer)
  *
  *  @tparam Iterator        a buffer iterator

--- a/src/ENDFtk/section/9/ReactionProduct/test/ReactionProduct.test.cpp
+++ b/src/ENDFtk/section/9/ReactionProduct/test/ReactionProduct.test.cpp
@@ -19,7 +19,7 @@ SCENARIO( "ReactionProduct" ) {
 
     std::string string = chunk();
 
-    WHEN( "the data is given explicitly" ) {
+    WHEN( "the data is given explicitly with boundaries and interpolants" ) {
 
       double qm = 2.224648e+6;
       double qi = 3.224648e+6;
@@ -35,6 +35,57 @@ SCENARIO( "ReactionProduct" ) {
                              std::move( interpolants ),
                              std::move( x ),
                              std::move( y ) );
+
+      THEN( "a ReactionProduct can be constructed and members can be tested" ) {
+
+        verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 9534, 9, 102 );
+
+        CHECK( buffer == string );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is read from a string/stream" ) {
+
+      auto begin = string.begin();
+      auto end = string.end();
+      long lineNumber = 1;
+
+      ReactionProduct chunk( begin, end, lineNumber, 9534, 9, 102 );
+
+      THEN( "a ReactionProduct can be constructed and members can be tested" ) {
+
+        verifyChunk( chunk );
+      } // THEN
+
+      THEN( "it can be printed" ) {
+
+        std::string buffer;
+        auto output = std::back_inserter( buffer );
+        chunk.print( output, 9534, 9, 102 );
+
+        CHECK( buffer == string );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is given explicitly with an interpolation type" ) {
+
+      double qm = 2.224648e+6;
+      double qi = 3.224648e+6;
+      long za = 95242;
+      long lfs = 2;
+      long interpolant = 5;
+      std::vector< double > x = { 1., 3. };
+      std::vector< double > y = { 2., 4. };
+
+      ReactionProduct chunk( qm, qi, za, lfs, std::move( x ), std::move( y ),
+                             interpolant );
 
       THEN( "a ReactionProduct can be constructed and members can be tested" ) {
 


### PR DESCRIPTION
Adding a few convenience constructors for MF3, MF9 and MF10 where only an interpolation type is given instead of boundaries and interpolants.