### PR TITLE
Fix/temp objects

### DIFF
--- a/python/src/definitions.hpp
+++ b/python/src/definitions.hpp
@@ -297,7 +297,8 @@ void addStandardFileDefinitions( PythonClass& file ) {
     "Return the section with the requested MT number\n\n"
     "Arguments:\n"
     "    self    the file\n"
-    "    mt      the MT number of the section to be returned"
+    "    mt      the MT number of the section to be returned",
+    python::return_value_policy::reference_internal
   )
   .def(
 
@@ -308,7 +309,8 @@ void addStandardFileDefinitions( PythonClass& file ) {
     "Return the section with the requested MT number\n\n"
     "Arguments:\n"
     "    self    the file\n"
-    "    mt      the MT number of the section to be returned"
+    "    mt      the MT number of the section to be returned",
+    python::return_value_policy::reference_internal
   )
   .def_property_readonly(
 

--- a/python/test/Test_ENDFtk_MF23_File.py
+++ b/python/test/Test_ENDFtk_MF23_File.py
@@ -87,6 +87,36 @@ class Test_ENDFtk_MF3_File( unittest.TestCase ) :
             self.assertAlmostEqual( 2.224631e+6, section.EFL )
             self.assertEqual( 5, section.interpolants[0] )
 
+            self.assertEqual( 1001, chunk.section( 1 ).ZA )
+            self.assertEqual( 0.0, chunk.section( 1 ).EPE )
+            self.assertEqual( 0.0, chunk.section( 1 ).EFL )
+            self.assertEqual( 5, chunk.section( 1 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.section( 2 ).ZA )
+            self.assertEqual( 0.0, chunk.section( 2 ).EPE )
+            self.assertEqual( 0.0, chunk.section( 2 ).EFL )
+            self.assertEqual( 2, chunk.section( 2 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.section( 102 ).ZA )
+            self.assertAlmostEqual( 2.224631e+6, chunk.section( 102 ).EPE )
+            self.assertAlmostEqual( 2.224631e+6, chunk.section( 102 ).EFL )
+            self.assertEqual( 5, chunk.section( 102 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.MT( 1 ).ZA )
+            self.assertEqual( 0.0, chunk.MT( 1 ).EPE )
+            self.assertEqual( 0.0, chunk.MT( 1 ).EFL )
+            self.assertEqual( 5, chunk.MT( 1 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.MT( 2 ).ZA )
+            self.assertEqual( 0.0, chunk.MT( 2 ).EPE )
+            self.assertEqual( 0.0, chunk.MT( 2 ).EFL )
+            self.assertEqual( 2, chunk.MT( 2 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.MT( 102 ).ZA )
+            self.assertAlmostEqual( 2.224631e+6, chunk.MT( 102 ).EPE )
+            self.assertAlmostEqual( 2.224631e+6, chunk.MT( 102 ).EFL )
+            self.assertEqual( 5, chunk.MT( 102 ).interpolants[0] )
+
             # verify string
             self.assertEqual( self.chunk + self.valid_FEND,
                               chunk.to_string( 125 ) )

--- a/python/test/Test_ENDFtk_MF27_File.py
+++ b/python/test/Test_ENDFtk_MF27_File.py
@@ -81,6 +81,30 @@ class Test_ENDFtk_MF27_File( unittest.TestCase ) :
             self.assertEqual( 1, section.Z )
             self.assertEqual( 5, section.interpolants[0] )
 
+            self.assertEqual( 1000, chunk.section( 1 ).ZA )
+            self.assertEqual( 1, chunk.section( 1 ).Z )
+            self.assertEqual( 5, chunk.section( 1 ).interpolants[0] )
+
+            self.assertEqual( 1000, chunk.section( 2 ).ZA )
+            self.assertEqual( 1, chunk.section( 2 ).Z )
+            self.assertEqual( 2, chunk.section( 2 ).interpolants[0] )
+
+            self.assertEqual( 1000, chunk.section( 102 ).ZA )
+            self.assertEqual( 1, chunk.section( 102 ).Z )
+            self.assertEqual( 5, chunk.section( 102 ).interpolants[0] )
+
+            self.assertEqual( 1000, chunk.MT( 1 ).ZA )
+            self.assertEqual( 1, chunk.MT( 1 ).Z )
+            self.assertEqual( 5, chunk.MT( 1 ).interpolants[0] )
+
+            self.assertEqual( 1000, chunk.MT( 2 ).ZA )
+            self.assertEqual( 1, chunk.MT( 2 ).Z )
+            self.assertEqual( 2, chunk.MT( 2 ).interpolants[0] )
+
+            self.assertEqual( 1000, chunk.MT( 102 ).ZA )
+            self.assertEqual( 1, chunk.MT( 102 ).Z )
+            self.assertEqual( 5, chunk.MT( 102 ).interpolants[0] )
+
             # verify string
             self.assertEqual( self.chunk + self.valid_FEND,
                               chunk.to_string( 100 ) )

--- a/python/test/Test_ENDFtk_MF3_File.py
+++ b/python/test/Test_ENDFtk_MF3_File.py
@@ -87,6 +87,36 @@ class Test_ENDFtk_MF3_File( unittest.TestCase ) :
             self.assertAlmostEqual( 2.224631e+6, section.QI )
             self.assertEqual( 5, section.interpolants[0] )
 
+            self.assertEqual( 1001, chunk.section( 1 ).ZA )
+            self.assertEqual( 0.0, chunk.section( 1 ).QM )
+            self.assertEqual( 0.0, chunk.section( 1 ).QI )
+            self.assertEqual( 5, chunk.section( 1 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.section( 2 ).ZA )
+            self.assertEqual( 0.0, chunk.section( 2 ).QM )
+            self.assertEqual( 0.0, chunk.section( 2 ).QI )
+            self.assertEqual( 2, chunk.section( 2 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.section( 102 ).ZA )
+            self.assertAlmostEqual( 2.224631e+6, chunk.section( 102 ).QM )
+            self.assertAlmostEqual( 2.224631e+6, chunk.section( 102 ).QI )
+            self.assertEqual( 5, chunk.section( 102 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.MT( 1 ).ZA )
+            self.assertEqual( 0.0, chunk.MT( 1 ).QM )
+            self.assertEqual( 0.0, chunk.MT( 1 ).QI )
+            self.assertEqual( 5, chunk.MT( 1 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.MT( 2 ).ZA )
+            self.assertEqual( 0.0, chunk.MT( 2 ).QM )
+            self.assertEqual( 0.0, chunk.MT( 2 ).QI )
+            self.assertEqual( 2, chunk.MT( 2 ).interpolants[0] )
+
+            self.assertEqual( 1001, chunk.MT( 102 ).ZA )
+            self.assertAlmostEqual( 2.224631e+6, chunk.MT( 102 ).QM )
+            self.assertAlmostEqual( 2.224631e+6, chunk.MT( 102 ).QI )
+            self.assertEqual( 5, chunk.MT( 102 ).interpolants[0] )
+
             # verify string
             self.assertEqual( self.chunk + self.valid_FEND,
                               chunk.to_string( 125 ) )


### PR DESCRIPTION
Fixing an issue with temporary objects coming out of parsed MF objects.

The following code in Python did not work:
```
tape = ENDFtk.tree.Tape.from_file(...)
mf3 = tape.materials.front().file(3).parse()

mf3.section(102).cross_sections[0]
```

The object returned by mf3.section(102) got garbage collected it seems.