### PR TITLE
Fix unit test still using catch-adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( DEFINED PROJECT_NAME )
 endif()
 
 project( ENDFtk
-  VERSION 1.0.0
+  VERSION 1.0.1
   LANGUAGES CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,17 @@ The CMake-based build system will try to automatically detect the installed vers
 
 A version of python 3.x is preferred.
 
-##### importError cannot import name <sysconfig> #####
+##### ImportError cannot import name <sysconfig> #####
 
 This error sometimes comes up when running the cmake command. This appears to be related to an incomplete/corrupted python installation. It can be rectified by installing the distutils package for the python version that is being used. On a linux system, the following command should install the distutils package:
 ```
 sudo apt install python3-distutils
 ```
+
+##### ImportError `GLIBCXX_3.4.30' not found
+
+A problem may occur if a user's installed python environment is through conda. The user will be able to build properly but all of the unit tests for python may fail due to GLIBCXX_3.4.30 being missing. This seems to be an a problem with conda not having GLIBCXX_3.4.30 in the path. If the user is able to compile ENDFtk, they have GLIBCXX_3.4.30. At which point, a symlink will need to be created to point the conda enviroment to where GLIBCXX_3.4.30 is installed.
+
 
 ##### cannot find python.h #####
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 # ENDFtk
 Toolkit for reading and interacting with ENDF-6 formatted files. This toolkit provides a full C++ library along with python bindings.
 
-## ENDFtk in python
+## Release and development versions
+For the latest version of ENDFtk and an overview of the latest changes, please see the [Release Notes](ReleaseNotes.md) or the [release](https://github.com/njoy/ENDFtk/releases) page.
 
-The python bindings for ENDFtk are still work in progress and should be used accordingly. Please report any issues encountered while using the python bindings using the issue tracker on this repository.
+The latest release version of ENDFtk can always be found at the head of the [main](https://github.com/njoy/ENDFtk) branch of this repository and every release is associated to a release tag. New versions are released on a regular basis (we aim to provide updates at least every three months). The latest development version of ENDFtk containing the latest updates and changes can be found in at the head of the [develop](https://github.com/njoy/ENDFtk/tree/develop) branch. This development version should be used with caution.
+
+## ENDFtk in python
 
 ### Installing ENDFtk for python
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,18 @@
+# Release Notes&mdash;ENDFtk
+Given here are some release notes for ENDFtk.
+
+## [ENDFtk v1.0.1](https://github.com/njoy/ENDFtk/pull/xxx)
+This update does not add any additional functionality.
+
+This update fixes the following issues:
+  - A compilation issue in a unit test that still used the old catch-adapter (see issue #193).
+
+## [ENDFtk v1.0.0](https://github.com/njoy/ENDFtk/pull/192)
+This release of ENDFtk has the following changes:
+  - All ZA values in the interface (the ZA value in the HEAD records, the ZAP values in the MF6 and MF26 reaction products, etc.) are now changed to integer types instead of a floating point type
+  - MF6 and MF26 now have additional functions that allow a user to look for specific reaction products
+  - MF9 and MF10 now have additional functions that allow a user to look for specific excited states
+
+The CMake files have also been updated to simplify adding new unit tests.
+
+This release cleans up some of the dependencies and updates most of the dependencies to more recent versions. In particular the Catch2 unit testing framework was updated to version 3.3.2. All unit tests were updated to use better floating point comparison available in this version of Catch2. A number of NJOY dependencies have also been consolidated into a single new dependency (the NJOY tools library) to reduce the number of dependencies to a more manageable level.

--- a/src/ENDFtk/section/5/WattSpectrum/test/WattSpectrum.test.cpp
+++ b/src/ENDFtk/section/5/WattSpectrum/test/WattSpectrum.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ENDFtk/section/5.hpp"
 
 // other includes
@@ -116,12 +119,12 @@ void verifyChunk( const WattSpectrum& chunk ) {
   CHECK( 3 == valueA.boundaries()[0] );
   CHECK( 3 == valueA.energies().size() );
   CHECK( 3 == valueA.values().size() );
-  CHECK( 1e-5 == Approx( valueA.energies()[0] ) );
-  CHECK( 1.5e+6 == Approx( valueA.energies()[1] ) );
-  CHECK( 3e+7 == Approx( valueA.energies()[2] ) );
-  CHECK( 9.77e+5 == Approx( valueA.values()[0] ) );
-  CHECK( 1e+6 == Approx( valueA.values()[1] ) );
-  CHECK( 1.06e+6 == Approx( valueA.values()[2] ) );
+  CHECK_THAT( 1e-5, WithinRel( valueA.energies()[0] ) );
+  CHECK_THAT( 1.5e+6, WithinRel( valueA.energies()[1] ) );
+  CHECK_THAT( 3e+7, WithinRel( valueA.energies()[2] ) );
+  CHECK_THAT( 9.77e+5, WithinRel( valueA.values()[0] ) );
+  CHECK_THAT( 1e+6, WithinRel( valueA.values()[1] ) );
+  CHECK_THAT( 1.06e+6, WithinRel( valueA.values()[2] ) );
 
   auto valueB = chunk.b();
   CHECK( 5 == valueB.NP() );
@@ -132,16 +135,16 @@ void verifyChunk( const WattSpectrum& chunk ) {
   CHECK( 5 == valueB.boundaries()[0] );
   CHECK( 5 == valueB.energies().size() );
   CHECK( 5 == valueB.values().size() );
-  CHECK( 1e-5 == Approx( valueB.energies()[0] ) );
-  CHECK( 1.5e+6 == Approx( valueB.energies()[1] ) );
-  CHECK( 1e+7 == Approx( valueB.energies()[2] ) );
-  CHECK( 1.22e+7 == Approx( valueB.energies()[3] ) );
-  CHECK( 3e+7 == Approx( valueB.energies()[4] ) );
-  CHECK( 2.546e-6 == Approx( valueB.values()[0] ) );
-  CHECK( 2.546e-6 == Approx( valueB.values()[1] ) );
-  CHECK( 2.474e-6 == Approx( valueB.values()[2] ) );
-  CHECK( 2.612e-6 == Approx( valueB.values()[3] ) );
-  CHECK( 2.62e-6 == Approx( valueB.values()[4] ) );
+  CHECK_THAT( 1e-5, WithinRel( valueB.energies()[0] ) );
+  CHECK_THAT( 1.5e+6, WithinRel( valueB.energies()[1] ) );
+  CHECK_THAT( 1e+7, WithinRel( valueB.energies()[2] ) );
+  CHECK_THAT( 1.22e+7, WithinRel( valueB.energies()[3] ) );
+  CHECK_THAT( 3e+7, WithinRel( valueB.energies()[4] ) );
+  CHECK_THAT( 2.546e-6, WithinRel( valueB.values()[0] ) );
+  CHECK_THAT( 2.546e-6, WithinRel( valueB.values()[1] ) );
+  CHECK_THAT( 2.474e-6, WithinRel( valueB.values()[2] ) );
+  CHECK_THAT( 2.612e-6, WithinRel( valueB.values()[3] ) );
+  CHECK_THAT( 2.62e-6, WithinRel( valueB.values()[4] ) );
 
   CHECK( 7 == chunk.NC() );
 }


### PR DESCRIPTION
A unit test (WattSpectrum.test.cpp in MF5) was still using the old Catch version. On gcc 11.4, this seemed to cause a compilation issue. This has been corrected.

In addition, a release notes file was added to more easily keep track of changes.