### PR TITLE
ENDFtk v1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( DEFINED PROJECT_NAME )
 endif()
 
 project( ENDFtk
-  VERSION 1.0.1
+  VERSION 1.0.2
   LANGUAGES CXX
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( DEFINED PROJECT_NAME )
 endif()
 
 project( ENDFtk
-  VERSION 1.0.2
+  VERSION 1.0.1
   LANGUAGES CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ cmake -DCMAKE_BUILD_TYPE=Release ../
 make -j8
 ```
 
-ENDFtk in python requires python 3.x so you will need to have at least one python 3.x installed. When multiple python versions are installed, it may be beneficial to include ```-DPYTHON_EXECUTABLE=$(which python3)``` in the cmake configuration step so that the default python3 version will be picked. The compilation will produce a dynamic library linked to the python libraries on the user's computer (it'll be named something like `ENDFtk.cpython-37m-darwin.so`). This name will also indicate which version of the python libraries this library is linked to. This is important since you will need to use the associated python version with the ENDFtk python package.
+The compilation will produce a number of dynamic libraries linked to the python libraries on the user's computer (these will be named something like `< component >.cpython-37m-darwin.so` with `< component >` the name of the component). The names of these dynamic libraries will also indicate which version of the python libraries they are linked against. This is important since you will need to use the associated python version along with them.
+
+ENDFtk in python requires python 3.x so you will need to have at least one python 3.x installed. When multiple python versions are installed, it may be beneficial to include ```-DPYTHON_EXECUTABLE=$(which python3)``` in the cmake configuration step so that the default python3 version will be picked.
 
 In order to use the ENDFtk python package, the user should make sure that the library is within the python path. This can be done in multiple ways. You can set that up by adding the ENDFtk build path to the python path `$PYTHONPATH` environmental variable on your machine, or by using the following in your python code:
 ```
@@ -125,4 +127,5 @@ sections = file.sections.copy()    # this is a list of MF6 sections that have be
 ```
 
 ## LICENSE
-The software contained in this repository is covered under the associated [LICENSE](LICENSE) file.
+This software is copyrighted by Los Alamos National Laboratory and distributed
+according to the conditions in the accompanying [LICENSE](LICENSE) file.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,14 +1,12 @@
 # Release Notes&mdash;ENDFtk
 Given here are some release notes for ENDFtk.
 
-## [ENDFtk v1.0.2](https://github.com/njoy/ENDFtk/pull/xxx)
-This update does not add any additional functionality.
-
-## [ENDFtk v1.0.1](https://github.com/njoy/ENDFtk/pull/194)
+## [ENDFtk v1.0.1](https://github.com/njoy/ENDFtk/pull/xxx)
 This update does not add any additional functionality.
 
 This update fixes the following issues:
   - A compilation issue in a unit test that still used the old catch-adapter (see issue #193).
+  - Macros for pybind11 were added where required so that other pybind11 bond libraries can accept ENDFtk components as input arguments on the python side (e.g. covariance matrice blocks). This is currently limited to all ENDFtk section components.
 
 ## [ENDFtk v1.0.0](https://github.com/njoy/ENDFtk/pull/192)
 This release of ENDFtk has the following changes:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,9 @@
 # Release Notes&mdash;ENDFtk
 Given here are some release notes for ENDFtk.
 
+## [ENDFtk v1.0.2](https://github.com/njoy/ENDFtk/pull/xxx)
+This update does not add any additional functionality.
+
 ## [ENDFtk v1.0.1](https://github.com/njoy/ENDFtk/pull/194)
 This update does not add any additional functionality.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,7 @@
 # Release Notes&mdash;ENDFtk
 Given here are some release notes for ENDFtk.
 
-## [ENDFtk v1.0.1](https://github.com/njoy/ENDFtk/pull/xxx)
+## [ENDFtk v1.0.1](https://github.com/njoy/ENDFtk/pull/195)
 This update does not add any additional functionality.
 
 This update fixes the following issues:

--- a/src/ENDFtk/macros.hpp
+++ b/src/ENDFtk/macros.hpp
@@ -1,0 +1,18 @@
+#ifndef NJOY_ENDFTK_PYBIND11_MACROS
+#define NJOY_ENDFTK_PYBIND11_MACROS
+
+// include files
+#ifdef PYBIND11
+#include <pybind11/detail/common.h>
+#endif
+
+// define PYTHON_EXPORT macro but only when PYBIND11 is defined
+#if !defined(PYTHON_EXPORT)
+#  ifdef PYBIND11
+#    define ENDFTK_PYTHON_EXPORT PYBIND11_EXPORT
+#  else
+#    define ENDFTK_PYTHON_EXPORT
+#  endif
+#endif
+
+#endif

--- a/src/ENDFtk/section/1/451.hpp
+++ b/src/ENDFtk/section/1/451.hpp
@@ -12,6 +12,7 @@
 #include "range/v3/view/single.hpp"
 #include "range/v3/view/split.hpp"
 #include "range/v3/view/transform.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/TextRecord.hpp"
 #include "ENDFtk/HeadRecord.hpp"
 #include "ENDFtk/ControlRecord.hpp"
@@ -30,7 +31,8 @@ namespace section {
    *  See ENDF102, section 1.1 for more information.
    */
   template<>
-  class Type< 1, 451 > : protected BaseWithoutMT< Type< 1, 451 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 1, 451 > : 
+    protected BaseWithoutMT< Type< 1, 451 > > {
 
     friend BaseWithoutMT< Type< 1, 451 > >;
 

--- a/src/ENDFtk/section/1/452.hpp
+++ b/src/ENDFtk/section/1/452.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/HeadRecord.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/section.hpp"
@@ -24,7 +25,8 @@ namespace section {
    *  See ENDF102, section 1.2 for more information.
    */
   template<>
-  class Type< 1, 452 > : protected BaseWithoutMT< Type< 1, 452 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 1, 452 > : 
+    protected BaseWithoutMT< Type< 1, 452 > > {
 
     friend BaseWithoutMT< Type< 1, 452 > >;
 

--- a/src/ENDFtk/section/1/455.hpp
+++ b/src/ENDFtk/section/1/455.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/InterpolationSequenceRecord.hpp"
@@ -29,7 +30,8 @@ namespace section{
    *  See ENDF102, section 1.3 for more information.
    */
   template<>
-  class Type< 1, 455 > : protected BaseWithoutMT< Type< 1, 455 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 1, 455 > : 
+    protected BaseWithoutMT< Type< 1, 455 > > {
 
     friend BaseWithoutMT< Type< 1, 455 > >;
 

--- a/src/ENDFtk/section/1/455/DecayConstants.hpp
+++ b/src/ENDFtk/section/1/455/DecayConstants.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 1.3 for more information.
  */
-class DecayConstants : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT DecayConstants : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/1/455/DecayConstants/src/generateList.hpp"

--- a/src/ENDFtk/section/1/455/EnergyDependentConstants.hpp
+++ b/src/ENDFtk/section/1/455/EnergyDependentConstants.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 1.3 for more information.
  */
-class EnergyDependentConstants :
+class ENDFTK_PYTHON_EXPORT EnergyDependentConstants :
   protected InterpolationSequenceRecord< DecayConstants > {
 
   /* auxiliary functions */

--- a/src/ENDFtk/section/1/455/EnergyIndependentConstants.hpp
+++ b/src/ENDFtk/section/1/455/EnergyIndependentConstants.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 1.3 for more information.
  */
-class EnergyIndependentConstants : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT EnergyIndependentConstants : protected ListRecord {
 
 public:
 

--- a/src/ENDFtk/section/1/456.hpp
+++ b/src/ENDFtk/section/1/456.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/HeadRecord.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/section.hpp"
@@ -28,7 +29,8 @@ namespace section {
    *  See ENDF102, section 1.4 for more information.
    */
   template<>
-  class Type< 1, 456 > : protected BaseWithoutMT< Type< 1, 456 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 1, 456 > : 
+    protected BaseWithoutMT< Type< 1, 456 > > {
 
     friend BaseWithoutMT< Type< 1, 456 > >;
 

--- a/src/ENDFtk/section/1/458.hpp
+++ b/src/ENDFtk/section/1/458.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/HeadRecord.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
@@ -26,7 +27,8 @@ namespace section{
    *  See ENDF102, section 1.5 for more information.
    */
   template<>
-  class Type< 1, 458 > : protected BaseWithoutMT< Type< 1, 458 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 1, 458 > : 
+    protected BaseWithoutMT< Type< 1, 458 > > {
 
     friend BaseWithoutMT< Type< 1, 458 > >;
 

--- a/src/ENDFtk/section/1/458/EnergyReleaseComponent.hpp
+++ b/src/ENDFtk/section/1/458/EnergyReleaseComponent.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 1.5 for more information.
  */
-class EnergyReleaseComponent : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT EnergyReleaseComponent : protected TabulationRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/1/458/EnergyReleaseComponent/src/verify.hpp"

--- a/src/ENDFtk/section/1/458/PolynomialComponents.hpp
+++ b/src/ENDFtk/section/1/458/PolynomialComponents.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 1.5 for more information.
  */
-class PolynomialComponents : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT PolynomialComponents : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/1/458/PolynomialComponents/src/verify.hpp"

--- a/src/ENDFtk/section/1/458/TabulatedComponents.hpp
+++ b/src/ENDFtk/section/1/458/TabulatedComponents.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 1.5 for more information.
  */
-class TabulatedComponents {
+class ENDFTK_PYTHON_EXPORT TabulatedComponents {
 
 public:
 

--- a/src/ENDFtk/section/1/458/ThermalPointComponents.hpp
+++ b/src/ENDFtk/section/1/458/ThermalPointComponents.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 1.5 for more information.
  */
-class ThermalPointComponents : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ThermalPointComponents : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/1/458/ThermalPointComponents/src/verify.hpp"

--- a/src/ENDFtk/section/1/460.hpp
+++ b/src/ENDFtk/section/1/460.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/readSequence.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/HeadRecord.hpp"
@@ -23,7 +24,8 @@ namespace section{
    *  See ENDF102, section 1.6 for more information.
    */
   template<>
-  class Type< 1, 460 > : protected BaseWithoutMT< Type< 1, 460 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 1, 460 > : 
+    protected BaseWithoutMT< Type< 1, 460 > > {
 
     friend BaseWithoutMT< Type< 1, 460 > >;
 

--- a/src/ENDFtk/section/1/460/ContinuousPhotons.hpp
+++ b/src/ENDFtk/section/1/460/ContinuousPhotons.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 1.6 for more information.
  */
-class ContinuousPhotons : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ContinuousPhotons : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/1/460/ContinuousPhotons/src/verifySize.hpp"

--- a/src/ENDFtk/section/1/460/DiscretePhotonMultiplicity.hpp
+++ b/src/ENDFtk/section/1/460/DiscretePhotonMultiplicity.hpp
@@ -4,7 +4,8 @@
  *
  *  See ENDF102, section 1.6 for more information.
  */
-class DiscretePhotonMultiplicity : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT DiscretePhotonMultiplicity : 
+  protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/1/460/DiscretePhotons.hpp
+++ b/src/ENDFtk/section/1/460/DiscretePhotons.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 1.6 for more information.
  */
-class DiscretePhotons {
+class ENDFTK_PYTHON_EXPORT DiscretePhotons {
 
   /* fields */
   std::vector< DiscretePhotonMultiplicity > photons_;

--- a/src/ENDFtk/section/1/PolynomialMultiplicity.hpp
+++ b/src/ENDFtk/section/1/PolynomialMultiplicity.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ListRecord.hpp"
 
 namespace njoy {
@@ -19,7 +20,7 @@ namespace section{
    *
    *  See ENDF102, section 1.2 for more information.
    */
-  class PolynomialMultiplicity : protected ListRecord {
+  class ENDFTK_PYTHON_EXPORT PolynomialMultiplicity : protected ListRecord {
 
   public:
 

--- a/src/ENDFtk/section/1/TabulatedMultiplicity.hpp
+++ b/src/ENDFtk/section/1/TabulatedMultiplicity.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 
 namespace njoy {
@@ -19,7 +20,7 @@ namespace section{
    *
    *  See ENDF102, section 1.2 for more information.
    */
-  class TabulatedMultiplicity : protected TabulationRecord {
+  class ENDFTK_PYTHON_EXPORT TabulatedMultiplicity : protected TabulationRecord {
 
   public:
 

--- a/src/ENDFtk/section/10.hpp
+++ b/src/ENDFtk/section/10.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -20,7 +21,7 @@ namespace section {
    *  See ENDF102, section 10.2 for more information.
    */
   template<>
-  class Type< 10 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 10 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/10/ReactionProduct.hpp
+++ b/src/ENDFtk/section/10/ReactionProduct.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 10.2 for more information.
  */
-class ReactionProduct : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT ReactionProduct : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/12.hpp
+++ b/src/ENDFtk/section/12.hpp
@@ -8,6 +8,7 @@
 // other includes
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/join.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -26,7 +27,7 @@ namespace section {
    *  See ENDF102, section 12.2 for more information.
    */
   template<>
-  class Type< 12 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 12 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/12/Multiplicities.hpp
+++ b/src/ENDFtk/section/12/Multiplicities.hpp
@@ -10,7 +10,7 @@
  *
  *  See ENDF102, section 12.2.1 for more information.
  */
-class Multiplicities {
+class ENDFTK_PYTHON_EXPORT Multiplicities {
 
 public:
 

--- a/src/ENDFtk/section/12/PartialMultiplicity.hpp
+++ b/src/ENDFtk/section/12/PartialMultiplicity.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 12.2.1 for more information.
  */
-class PartialMultiplicity : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT PartialMultiplicity : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/12/TotalMultiplicity.hpp
+++ b/src/ENDFtk/section/12/TotalMultiplicity.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 12.2.1 for more information.
  */
-class TotalMultiplicity : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT TotalMultiplicity : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/12/TransitionProbabilities.hpp
+++ b/src/ENDFtk/section/12/TransitionProbabilities.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 12.2.2 for more information.
  */
-class TransitionProbabilities : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT TransitionProbabilities : protected ListRecord {
 
 public:
 

--- a/src/ENDFtk/section/13.hpp
+++ b/src/ENDFtk/section/13.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -23,7 +24,7 @@ namespace section {
    *  See ENDF102, section 13.2 for more information.
    */
   template<>
-  class Type< 13 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 13 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/13/PartialCrossSection.hpp
+++ b/src/ENDFtk/section/13/PartialCrossSection.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 13.2 for more information.
  */
-class PartialCrossSection : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT PartialCrossSection : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/13/TotalCrossSection.hpp
+++ b/src/ENDFtk/section/13/TotalCrossSection.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 13.2 for more information.
  */
-class TotalCrossSection : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT TotalCrossSection : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/14.hpp
+++ b/src/ENDFtk/section/14.hpp
@@ -6,6 +6,7 @@
 
 // other includes
 #include "range/v3/algorithm/count_if.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -23,7 +24,7 @@ namespace section {
    *  See ENDF102, section 14.2 for more information.
    */
   template<>
-  class Type< 14 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 14 > : protected Base {
 
   protected:
 

--- a/src/ENDFtk/section/14/IsotropicDiscretePhoton.hpp
+++ b/src/ENDFtk/section/14/IsotropicDiscretePhoton.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 14.2.2 for more information.
  */
-class IsotropicDiscretePhoton {
+class ENDFTK_PYTHON_EXPORT IsotropicDiscretePhoton {
 
   /* fields */
   double eg_;

--- a/src/ENDFtk/section/14/LegendreDistributions.hpp
+++ b/src/ENDFtk/section/14/LegendreDistributions.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 14.2.2 for more information.
  */
-class LegendreDistributions :
+class ENDFTK_PYTHON_EXPORT LegendreDistributions :
   protected AngularDistributions< LegendreCoefficients > {
 
 public:

--- a/src/ENDFtk/section/14/TabulatedDistribution.hpp
+++ b/src/ENDFtk/section/14/TabulatedDistribution.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 14.2.3 for more information.
  */
-class TabulatedDistribution : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT TabulatedDistribution : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/14/TabulatedDistributions.hpp
+++ b/src/ENDFtk/section/14/TabulatedDistributions.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 14.2.3 for more information.
  */
-class TabulatedDistributions :
+class ENDFTK_PYTHON_EXPORT TabulatedDistributions :
   protected AngularDistributions< TabulatedDistribution > {
 
 public:

--- a/src/ENDFtk/section/15.hpp
+++ b/src/ENDFtk/section/15.hpp
@@ -7,6 +7,7 @@
 // other includes
 #include "range/v3/view/all.hpp"
 #include "range/v3/view/transform.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -18,7 +19,7 @@ namespace ENDFtk {
 namespace section {
 
   template<>
-  class Type< 15 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 15 > : protected Base {
   
   public:
   

--- a/src/ENDFtk/section/15/PartialDistribution.hpp
+++ b/src/ENDFtk/section/15/PartialDistribution.hpp
@@ -2,7 +2,7 @@
  *  @class
  *  @brief A distribution subsection of an MF15 section
  */
-class PartialDistribution {
+class ENDFTK_PYTHON_EXPORT PartialDistribution {
 
   Probability probability_;
   Distribution distribution_;

--- a/src/ENDFtk/section/2/151.hpp
+++ b/src/ENDFtk/section/2/151.hpp
@@ -16,6 +16,7 @@
 #include "range/v3/view/repeat_n.hpp"
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/zip_with.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"

--- a/src/ENDFtk/section/2/151/BreitWignerLValue.hpp
+++ b/src/ENDFtk/section/2/151/BreitWignerLValue.hpp
@@ -5,7 +5,8 @@
  *
  *  See ENDF102, section 2.2.1.1 for more information.
  */
-class BreitWignerLValue : protected BreitWignerReichMooreLValueBase {
+class ENDFTK_PYTHON_EXPORT BreitWignerLValue : 
+  protected BreitWignerReichMooreLValueBase {
 
 public:
 

--- a/src/ENDFtk/section/2/151/BreitWignerLValue/Resonance.hpp
+++ b/src/ENDFtk/section/2/151/BreitWignerLValue/Resonance.hpp
@@ -5,7 +5,7 @@
  *  See ENDF102, section 2.2.1.1 for more information.
  */
 template < typename Range >
-class Resonance {
+class ENDFTK_PYTHON_EXPORT Resonance {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/2/151/Isotope.hpp
+++ b/src/ENDFtk/section/2/151/Isotope.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.1 for more information.
  */
-class Isotope {
+class ENDFTK_PYTHON_EXPORT Isotope {
 
   /* fields */
   int zai_;

--- a/src/ENDFtk/section/2/151/MultiLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/2/151/MultiLevelBreitWigner.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.2.1.1 for more information.
  */
-class MultiLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT MultiLevelBreitWigner :
   protected BreitWignerReichMooreBase< BreitWignerLValue,
                                        MultiLevelBreitWigner > {
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class RMatrixLimited {
+class ENDFTK_PYTHON_EXPORT RMatrixLimited {
 
 public:
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited/BackgroundChannels.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/BackgroundChannels.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class BackgroundChannels {
+class ENDFTK_PYTHON_EXPORT BackgroundChannels {
 
 public:
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited/FrohnerBackgroundRMatrix.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/FrohnerBackgroundRMatrix.hpp
@@ -4,7 +4,8 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class FrohnerBackgroundRMatrix : protected BaseBackgroundRMatrix< FrohnerBackgroundRMatrix > {
+class ENDFTK_PYTHON_EXPORT FrohnerBackgroundRMatrix : 
+  protected BaseBackgroundRMatrix< FrohnerBackgroundRMatrix > {
 
   friend BaseBackgroundRMatrix< FrohnerBackgroundRMatrix >;
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited/NoBackgroundRMatrix.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/NoBackgroundRMatrix.hpp
@@ -4,7 +4,8 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class NoBackgroundRMatrix : protected BaseBackgroundRMatrix< NoBackgroundRMatrix > {
+class ENDFTK_PYTHON_EXPORT NoBackgroundRMatrix : 
+  protected BaseBackgroundRMatrix< NoBackgroundRMatrix > {
 
   friend BaseBackgroundRMatrix< NoBackgroundRMatrix >;
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited/ParticlePairs.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/ParticlePairs.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class ParticlePairs : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ParticlePairs : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/RMatrixLimited/ParticlePairs/src/generateList.hpp"

--- a/src/ENDFtk/section/2/151/RMatrixLimited/ResonanceChannels.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/ResonanceChannels.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class ResonanceChannels : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ResonanceChannels : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/RMatrixLimited/ResonanceChannels/src/generateList.hpp"

--- a/src/ENDFtk/section/2/151/RMatrixLimited/ResonanceParameters.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/ResonanceParameters.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class ResonanceParameters : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ResonanceParameters : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/RMatrixLimited/ResonanceParameters/src/generateList.hpp"

--- a/src/ENDFtk/section/2/151/RMatrixLimited/SammyBackgroundRMatrix.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/SammyBackgroundRMatrix.hpp
@@ -4,7 +4,8 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class SammyBackgroundRMatrix : protected BaseBackgroundRMatrix< SammyBackgroundRMatrix > {
+class ENDFTK_PYTHON_EXPORT SammyBackgroundRMatrix : 
+  protected BaseBackgroundRMatrix< SammyBackgroundRMatrix > {
 
   friend BaseBackgroundRMatrix< SammyBackgroundRMatrix >;
 

--- a/src/ENDFtk/section/2/151/RMatrixLimited/SpinGroup.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/SpinGroup.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class SpinGroup  {
+class ENDFTK_PYTHON_EXPORT SpinGroup  {
 
   /* fields */
   ResonanceChannels channels_;

--- a/src/ENDFtk/section/2/151/RMatrixLimited/TabulatedBackgroundRMatrix.hpp
+++ b/src/ENDFtk/section/2/151/RMatrixLimited/TabulatedBackgroundRMatrix.hpp
@@ -4,7 +4,8 @@
  *
  *  See ENDF102, section 2.2.1.6 for more information.
  */
-class TabulatedBackgroundRMatrix : protected BaseBackgroundRMatrix< TabulatedBackgroundRMatrix > {
+class ENDFTK_PYTHON_EXPORT TabulatedBackgroundRMatrix : 
+  protected BaseBackgroundRMatrix< TabulatedBackgroundRMatrix > {
 
   friend BaseBackgroundRMatrix< TabulatedBackgroundRMatrix >;
 

--- a/src/ENDFtk/section/2/151/ReichMoore.hpp
+++ b/src/ENDFtk/section/2/151/ReichMoore.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.2.1.2 for more information.
  */
-class ReichMoore :
+class ENDFTK_PYTHON_EXPORT ReichMoore :
   protected BreitWignerReichMooreBase< ReichMooreLValue, ReichMoore > {
 
   friend BreitWignerReichMooreBase< ReichMooreLValue, ReichMoore >;

--- a/src/ENDFtk/section/2/151/ReichMooreLValue.hpp
+++ b/src/ENDFtk/section/2/151/ReichMooreLValue.hpp
@@ -5,7 +5,8 @@
  *
  *  See ENDF102, section 2.2.1.2 for more information.
  */
-class ReichMooreLValue : protected BreitWignerReichMooreLValueBase {
+class ENDFTK_PYTHON_EXPORT ReichMooreLValue : 
+  protected BreitWignerReichMooreLValueBase {
 
 public:
 

--- a/src/ENDFtk/section/2/151/ReichMooreLValue/Resonance.hpp
+++ b/src/ENDFtk/section/2/151/ReichMooreLValue/Resonance.hpp
@@ -5,7 +5,7 @@
  *  See ENDF102, section 2.2.1.2 for more information.
  */
 template< typename Range >
-class Resonance {
+class ENDFTK_PYTHON_EXPORT Resonance {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/2/151/ResonanceRange.hpp
+++ b/src/ENDFtk/section/2/151/ResonanceRange.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.1 for more information.
  */
-class ResonanceRange {
+class ENDFTK_PYTHON_EXPORT ResonanceRange {
 
 public:
 

--- a/src/ENDFtk/section/2/151/ScatteringRadius.hpp
+++ b/src/ENDFtk/section/2/151/ScatteringRadius.hpp
@@ -5,7 +5,7 @@
  *  This class is a simplification of the TAB1 record which
  *  does not require the declaration of C1, C2, L1 and L2.
  */
-class ScatteringRadius : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT ScatteringRadius : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/2/151/SingleLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/2/151/SingleLevelBreitWigner.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.2.1.1 for more information.
  */
-class SingleLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT SingleLevelBreitWigner :
   protected BreitWignerReichMooreBase< BreitWignerLValue,
                                        SingleLevelBreitWigner > {
 

--- a/src/ENDFtk/section/2/151/SpecialCase.hpp
+++ b/src/ENDFtk/section/2/151/SpecialCase.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.1 for more information.
  */
-class SpecialCase {
+class ENDFTK_PYTHON_EXPORT SpecialCase {
 
   /* fields */
   double spi_;

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyDependent.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyDependent.hpp
@@ -20,7 +20,7 @@ struct LJValueType< UnresolvedEnergyDependent, GCC > {
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class UnresolvedEnergyDependent :
+class ENDFTK_PYTHON_EXPORT UnresolvedEnergyDependent :
   public UnresolvedBase< UnresolvedEnergyDependent > {
 
 public:

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyDependent/JValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyDependent/JValue.hpp
@@ -6,7 +6,7 @@
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class JValue : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT JValue : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/UnresolvedEnergyDependent/JValue/src/generateList.hpp"

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyDependent/LValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyDependent/LValue.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class LValue : protected UnresolvedLValueBase< JValue > {
+class ENDFTK_PYTHON_EXPORT LValue : protected UnresolvedLValueBase< JValue > {
 
 public:
 

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths.hpp
@@ -20,7 +20,7 @@ struct LJValueType< UnresolvedEnergyDependentFissionWidths, GCC > {
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class UnresolvedEnergyDependentFissionWidths :
+class ENDFTK_PYTHON_EXPORT UnresolvedEnergyDependentFissionWidths :
     public UnresolvedBaseWithoutSpin< UnresolvedEnergyDependentFissionWidths > {
 
 public:

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths/JValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths/JValue.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class JValue : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT JValue : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths/JValue/src/generateList.hpp"

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths/LValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths/LValue.hpp
@@ -6,7 +6,7 @@
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class LValue : protected UnresolvedLValueBase< JValue > {
+class ENDFTK_PYTHON_EXPORT LValue : protected UnresolvedLValueBase< JValue > {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/UnresolvedEnergyDependentFissionWidths/LValue/src/verifySize.hpp"

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent.hpp
@@ -19,7 +19,7 @@ struct LJValueType< UnresolvedEnergyIndependent, GCC > {
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class UnresolvedEnergyIndependent :
+class ENDFTK_PYTHON_EXPORT UnresolvedEnergyIndependent :
   public UnresolvedBase< UnresolvedEnergyIndependent > {
 
 public:

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent/JValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent/JValue.hpp
@@ -12,7 +12,7 @@
  *  See ENDF102, section 2.3.1 for more information.
  */
 template < typename Range >
-class JValue {
+class ENDFTK_PYTHON_EXPORT JValue {
 
   Range chunk;
 

--- a/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent/LValue.hpp
+++ b/src/ENDFtk/section/2/151/UnresolvedEnergyIndependent/LValue.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 2.3.1 for more information.
  */
-class LValue : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT LValue : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/2/151/UnresolvedEnergyIndependent/LValue/src/verifySize.hpp"

--- a/src/ENDFtk/section/23.hpp
+++ b/src/ENDFtk/section/23.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/section.hpp"
@@ -19,7 +20,7 @@ namespace section {
    *  See ENDF102, section 23.3 for more information.
    */
   template<>
-  class Type< 23 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 23 > : protected Base {
 
     /* fields */
     TabulationRecord table;

--- a/src/ENDFtk/section/26.hpp
+++ b/src/ENDFtk/section/26.hpp
@@ -14,6 +14,7 @@
 #include "range/v3/view/single.hpp"
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/tail.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -32,7 +33,7 @@ namespace section {
    *  See ENDF102, section 26.2 for more information.
    */
   template<>
-  class Type< 26 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 26 > : protected Base {
 
     #include "ENDFtk/section/6/src/verifySorted.hpp"
 

--- a/src/ENDFtk/section/26/ContinuumEnergyAngle.hpp
+++ b/src/ENDFtk/section/26/ContinuumEnergyAngle.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 26.2.1 for more information.
  */
-class ContinuumEnergyAngle {
+class ENDFTK_PYTHON_EXPORT ContinuumEnergyAngle {
 
 public:
 

--- a/src/ENDFtk/section/26/DiscreteTwoBodyScattering.hpp
+++ b/src/ENDFtk/section/26/DiscreteTwoBodyScattering.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 26.2.2 for more information.
  */
-class DiscreteTwoBodyScattering {
+class ENDFTK_PYTHON_EXPORT DiscreteTwoBodyScattering {
 
 public:
 

--- a/src/ENDFtk/section/26/EnergyTransfer.hpp
+++ b/src/ENDFtk/section/26/EnergyTransfer.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 26.2.3 for more information.
  */
-class EnergyTransfer : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT EnergyTransfer : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/26/Multiplicity.hpp
+++ b/src/ENDFtk/section/26/Multiplicity.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 26.2 for more information.
  */
-class Multiplicity : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT Multiplicity : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/26/ReactionProduct.hpp
+++ b/src/ENDFtk/section/26/ReactionProduct.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 26.2 for more information.
  */
-class ReactionProduct {
+class ENDFTK_PYTHON_EXPORT ReactionProduct {
 
   /* fields */
   Multiplicity multiplicity_;

--- a/src/ENDFtk/section/27.hpp
+++ b/src/ENDFtk/section/27.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/section.hpp"
@@ -19,7 +20,7 @@ namespace section{
    *  See ENDF102, section 27.2 for more information.
    */
   template<>
-  class Type< 27 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 27 > : protected Base {
 
     /* fields */
     TabulationRecord table;

--- a/src/ENDFtk/section/28.hpp
+++ b/src/ENDFtk/section/28.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -24,7 +25,7 @@ namespace section{
    *  See ENDF102, section 28.2 for more information.
    */
   template<>
-  class Type< 28 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 28 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/28/SubshellData.hpp
+++ b/src/ENDFtk/section/28/SubshellData.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 28.2 for more information.
  */
-class SubshellData : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT SubshellData : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/28/SubshellData/src/generateList.hpp"

--- a/src/ENDFtk/section/28/SubshellData/Transition.hpp
+++ b/src/ENDFtk/section/28/SubshellData/Transition.hpp
@@ -5,7 +5,7 @@
  *  See ENDF102, section 28.2 for more information.
  */
 template < typename Range >
-class Transition {
+class ENDFTK_PYTHON_EXPORT Transition {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/3.hpp
+++ b/src/ENDFtk/section/3.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/section.hpp"
@@ -19,7 +20,7 @@ namespace section {
    *  See ENDF102, section 3.2 for more information.
    */
   template<>
-  class Type< 3 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 3 > : protected Base {
 
     /* fields */
     TabulationRecord table;

--- a/src/ENDFtk/section/31.hpp
+++ b/src/ENDFtk/section/31.hpp
@@ -11,6 +11,7 @@
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/stride.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -31,7 +32,7 @@ namespace section{
    *  Caveat: lumped covariances don't make sense in MF31, so this is withheld.
    */
   template<>
-  class Type< 31 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 31 > : protected Base {
 
     /* fields */
     std::vector< ReactionBlock > reactions_;

--- a/src/ENDFtk/section/32/151.hpp
+++ b/src/ENDFtk/section/32/151.hpp
@@ -13,6 +13,7 @@
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/transform.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/record.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
@@ -31,7 +32,8 @@ namespace section {
    *  See ENDF102, section 32.1 for more information.
    */
   template<>
-  class Type< 32, 151 > : protected BaseWithoutMT< Type< 32, 151 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 32, 151 > : 
+    protected BaseWithoutMT< Type< 32, 151 > > {
 
   public:
 

--- a/src/ENDFtk/section/32/151/CompactBreitWignerUncertainties.hpp
+++ b/src/ENDFtk/section/32/151/CompactBreitWignerUncertainties.hpp
@@ -5,7 +5,8 @@
  *
  *  See ENDF102, section 32.2.3.1 for more information.
  */
-class CompactBreitWignerUncertainties : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT CompactBreitWignerUncertainties : 
+  protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/CompactBreitWignerUncertainties/src/verifySize.hpp"

--- a/src/ENDFtk/section/32/151/CompactBreitWignerUncertainties/Resonance.hpp
+++ b/src/ENDFtk/section/32/151/CompactBreitWignerUncertainties/Resonance.hpp
@@ -6,7 +6,7 @@
  *  See ENDF102, section 32.2.3.1 for more information.
  */
 template < typename Range >
-class Resonance {
+class ENDFTK_PYTHON_EXPORT Resonance {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/32/151/CompactCorrelationMatrix.hpp
+++ b/src/ENDFtk/section/32/151/CompactCorrelationMatrix.hpp
@@ -10,7 +10,7 @@
  *
  *  See ENDF102, section 0.6.4.9 and 32.2.3 for more information.
  */
-class CompactCorrelationMatrix {
+class ENDFTK_PYTHON_EXPORT CompactCorrelationMatrix {
 
   /* fields */
   int ndigit_;

--- a/src/ENDFtk/section/32/151/CompactMultiLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/32/151/CompactMultiLevelBreitWigner.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.3.1
  */
-class CompactMultiLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT CompactMultiLevelBreitWigner :
   protected CompactCovarianceBase<
                 CompactBreitWignerUncertainties,
                 double,

--- a/src/ENDFtk/section/32/151/CompactRMatrixLimited.hpp
+++ b/src/ENDFtk/section/32/151/CompactRMatrixLimited.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.3.2
  */
-class CompactRMatrixLimited :
+class ENDFTK_PYTHON_EXPORT CompactRMatrixLimited :
   protected CompactCovarianceBase<
                 CompactRMatrixLimitedUncertainties,
                 ReichMooreScatteringRadiusUncertainties,

--- a/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties.hpp
+++ b/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties.hpp
@@ -6,7 +6,7 @@
  *  See ENDF102, section 32.2.3.3 for more information - if you don't value
  *  your sanity.
  */
-class CompactRMatrixLimitedUncertainties {
+class ENDFTK_PYTHON_EXPORT CompactRMatrixLimitedUncertainties {
 
 public:
 

--- a/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ParticlePairs.hpp
+++ b/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ParticlePairs.hpp
@@ -9,7 +9,7 @@
  *  See ENDF102, section 32.2.3.3 for more information - if you don't value
  *  your sanity.
  */
-class ParticlePairs : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ParticlePairs : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ParticlePairs/src/generateList.hpp"

--- a/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ResonanceChannels.hpp
+++ b/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ResonanceChannels.hpp
@@ -8,7 +8,7 @@
  *  See ENDF102, section 32.2.3.3 for more information - if you don't value
  *  your sanity.
  */
-class ResonanceChannels : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ResonanceChannels : protected ListRecord {
 
   /* auxiliary functions - blatantly taken from MF2 MT151 LRF = 7 */
   #include "ENDFtk/section/2/151/RMatrixLimited/ResonanceChannels/src/generateList.hpp"

--- a/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ResonanceParameters.hpp
+++ b/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ResonanceParameters.hpp
@@ -12,7 +12,7 @@
  *  See ENDF102, section 32.2.3.3 for more information - if you don't value
  *  your sanity.
  */
-class ResonanceParameters : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ResonanceParameters : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/ResonanceParameters/src/generateList.hpp"

--- a/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/SpinGroup.hpp
+++ b/src/ENDFtk/section/32/151/CompactRMatrixLimitedUncertainties/SpinGroup.hpp
@@ -8,7 +8,7 @@
  *  See ENDF102, section 32.2.3.3 for more information - if you don't value
  *  your sanity.
  */
-class SpinGroup  {
+class ENDFTK_PYTHON_EXPORT SpinGroup  {
 
   /* fields */
   ResonanceChannels channels_;

--- a/src/ENDFtk/section/32/151/CompactReichMoore.hpp
+++ b/src/ENDFtk/section/32/151/CompactReichMoore.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.3.2
  */
-class CompactReichMoore :
+class ENDFTK_PYTHON_EXPORT CompactReichMoore :
   protected CompactCovarianceBase<
                 CompactReichMooreUncertainties,
                 ReichMooreScatteringRadiusUncertainties,

--- a/src/ENDFtk/section/32/151/CompactReichMooreUncertainties.hpp
+++ b/src/ENDFtk/section/32/151/CompactReichMooreUncertainties.hpp
@@ -5,7 +5,8 @@
  *
  *  See ENDF102, section 32.2.3.2 for more information.
  */
-class CompactReichMooreUncertainties : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT CompactReichMooreUncertainties : 
+  protected ListRecord {
 
   // blatantly stolen from CompactBreitWignerUncertainties
   #include "ENDFtk/section/32/151/CompactBreitWignerUncertainties/src/verifySize.hpp"

--- a/src/ENDFtk/section/32/151/CompactReichMooreUncertainties/Resonance.hpp
+++ b/src/ENDFtk/section/32/151/CompactReichMooreUncertainties/Resonance.hpp
@@ -6,7 +6,7 @@
  *  See ENDF102, section 32.2.3.2 for more information.
  */
 template < typename Range >
-class Resonance {
+class ENDFTK_PYTHON_EXPORT Resonance {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/32/151/CompactSingleLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/32/151/CompactSingleLevelBreitWigner.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.3.1
  */
-class CompactSingleLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT CompactSingleLevelBreitWigner :
   protected CompactCovarianceBase<
                 CompactBreitWignerUncertainties,
                 double,

--- a/src/ENDFtk/section/32/151/GeneralCovarianceBase.hpp
+++ b/src/ENDFtk/section/32/151/GeneralCovarianceBase.hpp
@@ -11,7 +11,7 @@
 template < typename ShortRangeCovarianceBlock,
            typename RadiusUncertainty,
            typename Derived >
-class GeneralCovarianceBase {
+class ENDFTK_PYTHON_EXPORT GeneralCovarianceBase {
 
   /* fields */
   double spi_;

--- a/src/ENDFtk/section/32/151/GeneralMultiLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/32/151/GeneralMultiLevelBreitWigner.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2
  */
-class GeneralMultiLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT GeneralMultiLevelBreitWigner :
   protected GeneralCovarianceBase<
                 ShortRangeBreitWignerBlock,
                 double,

--- a/src/ENDFtk/section/32/151/GeneralRMatrixLimited.hpp
+++ b/src/ENDFtk/section/32/151/GeneralRMatrixLimited.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2
  */
-class GeneralRMatrixLimited :
+class ENDFTK_PYTHON_EXPORT GeneralRMatrixLimited :
   protected GeneralCovarianceBase<
                 ShortRangeRMatrixLimitedBlock,
                 ReichMooreScatteringRadiusUncertainties,

--- a/src/ENDFtk/section/32/151/GeneralReichMoore.hpp
+++ b/src/ENDFtk/section/32/151/GeneralReichMoore.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2
  */
-class GeneralReichMoore :
+class ENDFTK_PYTHON_EXPORT GeneralReichMoore :
   protected GeneralCovarianceBase<
                 ShortRangeReichMooreBlock,
                 ReichMooreScatteringRadiusUncertainties,

--- a/src/ENDFtk/section/32/151/GeneralSingleLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/32/151/GeneralSingleLevelBreitWigner.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2
  */
-class GeneralSingleLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT GeneralSingleLevelBreitWigner :
   protected GeneralCovarianceBase<
                 ShortRangeBreitWignerBlock,
                 double,

--- a/src/ENDFtk/section/32/151/Isotope.hpp
+++ b/src/ENDFtk/section/32/151/Isotope.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 2.1 for more information.
  */
-class Isotope {
+class ENDFTK_PYTHON_EXPORT Isotope {
 
   /* fields */
   double zai_;

--- a/src/ENDFtk/section/32/151/LimitedBreitWignerLValue.hpp
+++ b/src/ENDFtk/section/32/151/LimitedBreitWignerLValue.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 32.2.1 for more information.
  */
-class LimitedBreitWignerLValue : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT LimitedBreitWignerLValue : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/LimitedBreitWignerLValue/src/verifySize.hpp"

--- a/src/ENDFtk/section/32/151/LimitedBreitWignerLValue/Resonance.hpp
+++ b/src/ENDFtk/section/32/151/LimitedBreitWignerLValue/Resonance.hpp
@@ -6,7 +6,7 @@
  *  See ENDF102, section 32.2.1 for more information.
  */
 template < typename Range >
-class Resonance {
+class ENDFTK_PYTHON_EXPORT Resonance {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/32/151/LimitedMultiLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/32/151/LimitedMultiLevelBreitWigner.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.1
  */
-class LimitedMultiLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT LimitedMultiLevelBreitWigner :
   protected LimitedCovarianceBase< LimitedMultiLevelBreitWigner > {
 
   friend LimitedCovarianceBase< LimitedMultiLevelBreitWigner >;

--- a/src/ENDFtk/section/32/151/LimitedSingleLevelBreitWigner.hpp
+++ b/src/ENDFtk/section/32/151/LimitedSingleLevelBreitWigner.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.1
  */
-class LimitedSingleLevelBreitWigner :
+class ENDFTK_PYTHON_EXPORT LimitedSingleLevelBreitWigner :
   protected LimitedCovarianceBase< LimitedSingleLevelBreitWigner > {
 
   friend LimitedCovarianceBase< LimitedSingleLevelBreitWigner >;

--- a/src/ENDFtk/section/32/151/ReichMooreScatteringRadiusUncertainties.hpp
+++ b/src/ENDFtk/section/32/151/ReichMooreScatteringRadiusUncertainties.hpp
@@ -5,7 +5,8 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class ReichMooreScatteringRadiusUncertainties : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ReichMooreScatteringRadiusUncertainties : 
+  protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/ReichMooreScatteringRadiusUncertainties/src/generateList.hpp"

--- a/src/ENDFtk/section/32/151/ResonanceRange.hpp
+++ b/src/ENDFtk/section/32/151/ResonanceRange.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.1 for more information.
  */
-class ResonanceRange {
+class ENDFTK_PYTHON_EXPORT ResonanceRange {
 
 public:
 

--- a/src/ENDFtk/section/32/151/ScatteringRadiusCovariances.hpp
+++ b/src/ENDFtk/section/32/151/ScatteringRadiusCovariances.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2 for more information.
  */
-class ScatteringRadiusCovariances {
+class ENDFTK_PYTHON_EXPORT ScatteringRadiusCovariances {
 
   /* fields */
   std::vector< ExplicitCovariance > ni_;

--- a/src/ENDFtk/section/32/151/ShortRangeBreitWignerBlock.hpp
+++ b/src/ENDFtk/section/32/151/ShortRangeBreitWignerBlock.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class ShortRangeBreitWignerBlock :
+class ENDFTK_PYTHON_EXPORT ShortRangeBreitWignerBlock :
   protected ShortRangeBreitWignerReichMooreBlockBase {
 
 public:

--- a/src/ENDFtk/section/32/151/ShortRangeBreitWignerReichMooreBlockBase.hpp
+++ b/src/ENDFtk/section/32/151/ShortRangeBreitWignerReichMooreBlockBase.hpp
@@ -5,7 +5,8 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class ShortRangeBreitWignerReichMooreBlockBase : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ShortRangeBreitWignerReichMooreBlockBase : 
+  protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/ShortRangeBreitWignerReichMooreBlockBase/src/verifySize.hpp"

--- a/src/ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock.hpp
+++ b/src/ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class ShortRangeRMatrixLimitedBlock {
+class ENDFTK_PYTHON_EXPORT ShortRangeRMatrixLimitedBlock {
 
 public:
 

--- a/src/ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock/CovarianceMatrix.hpp
+++ b/src/ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock/CovarianceMatrix.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class CovarianceMatrix : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT CovarianceMatrix : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock/CovarianceMatrix/src/verifySize.hpp"

--- a/src/ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock/ResonanceParameters.hpp
+++ b/src/ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock/ResonanceParameters.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class ResonanceParameters : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ResonanceParameters : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/32/151/ShortRangeRMatrixLimitedBlock/ResonanceParameters/src/generateList.hpp"

--- a/src/ENDFtk/section/32/151/ShortRangeReichMooreBlock.hpp
+++ b/src/ENDFtk/section/32/151/ShortRangeReichMooreBlock.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 32.2.2 for more information.
  */
-class ShortRangeReichMooreBlock :
+class ENDFTK_PYTHON_EXPORT ShortRangeReichMooreBlock :
   protected ShortRangeBreitWignerReichMooreBlockBase {
 
 public:

--- a/src/ENDFtk/section/32/151/UnresolvedRelativeCovariances.hpp
+++ b/src/ENDFtk/section/32/151/UnresolvedRelativeCovariances.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 32.2.4 for more information.
  */
-class UnresolvedRelativeCovariances {
+class ENDFTK_PYTHON_EXPORT UnresolvedRelativeCovariances {
 
 public:
 

--- a/src/ENDFtk/section/33.hpp
+++ b/src/ENDFtk/section/33.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/range/conversion.hpp"
 #include "range/v3/view/all.hpp"
 #include "range/v3/view/concat.hpp"
@@ -28,7 +29,7 @@ namespace section{
    *  See ENDF102, section 33.2 for more information.
    */
   template<>
-  class Type< 33 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 33 > : protected Base {
 
     /* fields */
     int mtl_;

--- a/src/ENDFtk/section/34.hpp
+++ b/src/ENDFtk/section/34.hpp
@@ -11,6 +11,7 @@
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/stride.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -28,7 +29,7 @@ namespace section{
    *  See ENDF102, section 34.2 for more information.
    */
   template<>
-  class Type< 34 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 34 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/34/LegendreBlock.hpp
+++ b/src/ENDFtk/section/34/LegendreBlock.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 34.2 for more information.
  */
-class LegendreBlock {
+class ENDFTK_PYTHON_EXPORT LegendreBlock {
 
   /* fields */
   int order_;

--- a/src/ENDFtk/section/34/ReactionBlock.hpp
+++ b/src/ENDFtk/section/34/ReactionBlock.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 34.2 for more information.
  */
-class ReactionBlock {
+class ENDFTK_PYTHON_EXPORT ReactionBlock {
 
   /* fields */
   int mt1_;

--- a/src/ENDFtk/section/35.hpp
+++ b/src/ENDFtk/section/35.hpp
@@ -11,6 +11,7 @@
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/stride.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -27,7 +28,7 @@ namespace section{
    *  See ENDF102, section 35.2 for more information.
    */
   template<>
-  class Type< 35 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 35 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/35/SquareMatrix.hpp
+++ b/src/ENDFtk/section/35/SquareMatrix.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 35.2 for more information.
  */
-class SquareMatrix : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT SquareMatrix : protected ListRecord {
 
   #include "ENDFtk/section/35/SquareMatrix/src/verifyLB.hpp"
 

--- a/src/ENDFtk/section/4.hpp
+++ b/src/ENDFtk/section/4.hpp
@@ -10,6 +10,7 @@
 #include "range/v3/view/transform.hpp"
 #include "range/v3/view/empty.hpp"
 #include "range/v3/view/any_view.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -28,7 +29,7 @@ namespace section {
    *  See ENDF102, section 4.2 for more information.
    */
   template<>
-  class Type< 4 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 4 > : protected Base {
 
   protected:
 

--- a/src/ENDFtk/section/4/AngularDistributions.hpp
+++ b/src/ENDFtk/section/4/AngularDistributions.hpp
@@ -3,7 +3,7 @@
  *  @brief Base class for Legendre or tabulated angular distributions
  */
 template < typename Records >
-class AngularDistributions :
+class ENDFTK_PYTHON_EXPORT AngularDistributions :
   protected InterpolationSequenceRecord< Records > {
 
 protected:

--- a/src/ENDFtk/section/4/Isotropic.hpp
+++ b/src/ENDFtk/section/4/Isotropic.hpp
@@ -11,7 +11,7 @@
  *
  *  See ENDF102, section 4.2.1 for more information.
  */
-class Isotropic {
+class ENDFTK_PYTHON_EXPORT Isotropic {
 
 public:
 

--- a/src/ENDFtk/section/4/LegendreCoefficients.hpp
+++ b/src/ENDFtk/section/4/LegendreCoefficients.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 4.2.1 for more information.
  */
-class LegendreCoefficients : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT LegendreCoefficients : protected ListRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/4/LegendreDistributions.hpp
+++ b/src/ENDFtk/section/4/LegendreDistributions.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 4.2.1 for more information.
  */
-class LegendreDistributions :
+class ENDFTK_PYTHON_EXPORT LegendreDistributions :
   protected AngularDistributions< LegendreCoefficients > {
 
 public:

--- a/src/ENDFtk/section/4/MixedDistributions.hpp
+++ b/src/ENDFtk/section/4/MixedDistributions.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 4.2.3 for more information.
  */
-class MixedDistributions {
+class ENDFTK_PYTHON_EXPORT MixedDistributions {
 
   /* fields */
   LegendreDistributions legendre_;

--- a/src/ENDFtk/section/4/TabulatedDistribution.hpp
+++ b/src/ENDFtk/section/4/TabulatedDistribution.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 4.2.2 for more information.
  */
-class TabulatedDistribution : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT TabulatedDistribution : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/4/TabulatedDistributions.hpp
+++ b/src/ENDFtk/section/4/TabulatedDistributions.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 4.2.2 for more information.
  */
-class TabulatedDistributions :
+class ENDFTK_PYTHON_EXPORT TabulatedDistributions :
   protected AngularDistributions< TabulatedDistribution > {
 
 public:

--- a/src/ENDFtk/section/40.hpp
+++ b/src/ENDFtk/section/40.hpp
@@ -11,6 +11,7 @@
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/stride.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -28,7 +29,7 @@ namespace section{
    *  See ENDF102, section 40.2 for more information.
    */
   template<>
-  class Type< 40 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 40 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/40/LevelBlock.hpp
+++ b/src/ENDFtk/section/40/LevelBlock.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 40.2 for more information.
  */
-class LevelBlock {
+class ENDFTK_PYTHON_EXPORT LevelBlock {
 
   /* fields */
   double qm_;

--- a/src/ENDFtk/section/5.hpp
+++ b/src/ENDFtk/section/5.hpp
@@ -8,6 +8,7 @@
 // other includes
 #include "range/v3/view/all.hpp"
 #include "range/v3/view/transform.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -19,7 +20,7 @@ namespace ENDFtk {
 namespace section {
 
   template<>
-  class Type< 5 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 5 > : protected Base {
   
   public:
   

--- a/src/ENDFtk/section/5/DistributionFunction.hpp
+++ b/src/ENDFtk/section/5/DistributionFunction.hpp
@@ -5,7 +5,7 @@
  *  This class is a simplification of the TAB1 record which
  *  does not require the declaration of C1, C2, L1 and L2.
  */
-class DistributionFunction : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT DistributionFunction : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/5/EffectiveTemperature.hpp
+++ b/src/ENDFtk/section/5/EffectiveTemperature.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 5 for more information.
  */
-class EffectiveTemperature : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT EffectiveTemperature : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/5/EvaporationSpectrum.hpp
+++ b/src/ENDFtk/section/5/EvaporationSpectrum.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 5.1.1.4 and 5.2.4 for more information.
  */
-class EvaporationSpectrum : protected EffectiveTemperature {
+class ENDFTK_PYTHON_EXPORT EvaporationSpectrum : protected EffectiveTemperature {
 
 public:
 

--- a/src/ENDFtk/section/5/GeneralEvaporationSpectrum.hpp
+++ b/src/ENDFtk/section/5/GeneralEvaporationSpectrum.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 5.1.1.2 and 5.2.2 for more information.
  */
-class GeneralEvaporationSpectrum {
+class ENDFTK_PYTHON_EXPORT GeneralEvaporationSpectrum {
 
   EffectiveTemperature temperature_;
   DistributionFunction distribution_;

--- a/src/ENDFtk/section/5/MadlandNixSpectrum.hpp
+++ b/src/ENDFtk/section/5/MadlandNixSpectrum.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 5.1.1.6 and 5.2.6 for more information.
  */
-class MadlandNixSpectrum : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT MadlandNixSpectrum : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/5/MaxwellianFissionSpectrum.hpp
+++ b/src/ENDFtk/section/5/MaxwellianFissionSpectrum.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 5.1.1.3 and 5.2.3 for more information.
  */
-class MaxwellianFissionSpectrum : protected EffectiveTemperature {
+class ENDFTK_PYTHON_EXPORT MaxwellianFissionSpectrum : protected EffectiveTemperature {
 
 public:
 

--- a/src/ENDFtk/section/5/Parameter.hpp
+++ b/src/ENDFtk/section/5/Parameter.hpp
@@ -5,7 +5,7 @@
  *  This class is a simplification of the TAB1 record which
  *  does not require the declaration of C1, C2, L1 and L2.
  */
-class Parameter : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT Parameter : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/5/PartialDistribution.hpp
+++ b/src/ENDFtk/section/5/PartialDistribution.hpp
@@ -2,7 +2,7 @@
  *  @class
  *  @brief A distribution subsection of an MF5 section
  */
-class PartialDistribution {
+class ENDFTK_PYTHON_EXPORT PartialDistribution {
 
   Probability probability_;
   Distribution distribution_;

--- a/src/ENDFtk/section/5/Probability.hpp
+++ b/src/ENDFtk/section/5/Probability.hpp
@@ -11,7 +11,7 @@ class PartialDistribution;
  *
  *  See ENDF102, section 5 for more information.
  */
-class Probability : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT Probability : protected TabulationRecord {
 
   friend PartialDistribution;
 

--- a/src/ENDFtk/section/5/TabulatedSpectrum.hpp
+++ b/src/ENDFtk/section/5/TabulatedSpectrum.hpp
@@ -11,7 +11,7 @@
  *
  *  See ENDF102, section 5.1.1.1 and 5.2.1 for more information.
  */
-class TabulatedSpectrum {
+class ENDFTK_PYTHON_EXPORT TabulatedSpectrum {
 
 public:
 

--- a/src/ENDFtk/section/5/TabulatedSpectrum/OutgoingEnergyDistribution.hpp
+++ b/src/ENDFtk/section/5/TabulatedSpectrum/OutgoingEnergyDistribution.hpp
@@ -7,7 +7,8 @@
  *
  *  See ENDF102, section 5.2.1 for more information.
  */
-class OutgoingEnergyDistribution : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT OutgoingEnergyDistribution : 
+    protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/5/WattSpectrum.hpp
+++ b/src/ENDFtk/section/5/WattSpectrum.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 5.1.1.5 and 5.2.5 for more information.
  */
-class WattSpectrum {
+class ENDFTK_PYTHON_EXPORT WattSpectrum {
 
   std::array< Parameter, 2 > parameters_;
 

--- a/src/ENDFtk/section/6.hpp
+++ b/src/ENDFtk/section/6.hpp
@@ -19,6 +19,7 @@
 #include "range/v3/view/tail.hpp"
 #include "range/v3/view/transform.hpp"
 #include "range/v3/view/zip_with.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -36,7 +37,7 @@ namespace section {
    *  See ENDF102, section 6.2 for more information.
    */
   template<>
-  class Type< 6 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 6 > : protected Base {
 
     #include "ENDFtk/section/6/src/verifySorted.hpp"
 

--- a/src/ENDFtk/section/6/ChargedParticleElasticScattering.hpp
+++ b/src/ENDFtk/section/6/ChargedParticleElasticScattering.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 6.2.7 for more information.
  */
-class ChargedParticleElasticScattering {
+class ENDFTK_PYTHON_EXPORT ChargedParticleElasticScattering {
 
 public:
 

--- a/src/ENDFtk/section/6/ContinuumEnergyAngle.hpp
+++ b/src/ENDFtk/section/6/ContinuumEnergyAngle.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 6.2.3 for more information.
  */
-class ContinuumEnergyAngle {
+class ENDFTK_PYTHON_EXPORT ContinuumEnergyAngle {
 
 public:
 

--- a/src/ENDFtk/section/6/ContinuumEnergyAngle/KalbachMann.hpp
+++ b/src/ENDFtk/section/6/ContinuumEnergyAngle/KalbachMann.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 6.2.3.1 for more information.
  */
-class KalbachMann : protected Base {
+class ENDFTK_PYTHON_EXPORT KalbachMann : protected Base {
 
   /* auxiliary functions */
   #include "ENDFtk/section/6/ContinuumEnergyAngle/KalbachMann/src/verifyNA.hpp"

--- a/src/ENDFtk/section/6/ContinuumEnergyAngle/LegendreCoefficients.hpp
+++ b/src/ENDFtk/section/6/ContinuumEnergyAngle/LegendreCoefficients.hpp
@@ -12,7 +12,7 @@
  *
  *  See ENDF102, section 6.2.3.1 for more information.
  */
-class LegendreCoefficients : protected Base {
+class ENDFTK_PYTHON_EXPORT LegendreCoefficients : protected Base {
 
   /* auxiliary functions */
   #include "ENDFtk/section/6/ContinuumEnergyAngle/LegendreCoefficients/src/generateList.hpp"

--- a/src/ENDFtk/section/6/ContinuumEnergyAngle/TabulatedDistribution.hpp
+++ b/src/ENDFtk/section/6/ContinuumEnergyAngle/TabulatedDistribution.hpp
@@ -12,7 +12,7 @@
  *
  *  See ENDF102, section 6.2.3.1 for more information.
  */
-class TabulatedDistribution : protected Base {
+class ENDFTK_PYTHON_EXPORT TabulatedDistribution : protected Base {
 
   /* fields */
   int lang_;

--- a/src/ENDFtk/section/6/ContinuumEnergyAngle/ThermalScatteringData.hpp
+++ b/src/ENDFtk/section/6/ContinuumEnergyAngle/ThermalScatteringData.hpp
@@ -7,7 +7,7 @@
  *
  *  See NJOY2016 manual, section 7.4 for more information.
  */
-class ThermalScatteringData : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ThermalScatteringData : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/6/ContinuumEnergyAngle/ThermalScatteringData/src/generateList.hpp"

--- a/src/ENDFtk/section/6/DefinedElsewhere.hpp
+++ b/src/ENDFtk/section/6/DefinedElsewhere.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 6.2.4 for more information.
  */
-class DefinedElsewhere : protected NoLawDataGiven {
+class ENDFTK_PYTHON_EXPORT DefinedElsewhere : protected NoLawDataGiven {
 
   /* fields */
   int law_;

--- a/src/ENDFtk/section/6/DiscreteTwoBodyRecoils.hpp
+++ b/src/ENDFtk/section/6/DiscreteTwoBodyRecoils.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 6.2.5 for more information.
  */
-class DiscreteTwoBodyRecoils : protected NoLawDataGiven {
+class ENDFTK_PYTHON_EXPORT DiscreteTwoBodyRecoils : protected NoLawDataGiven {
 
 public:
 

--- a/src/ENDFtk/section/6/DiscreteTwoBodyScattering.hpp
+++ b/src/ENDFtk/section/6/DiscreteTwoBodyScattering.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 6.2.4 for more information.
  */
-class DiscreteTwoBodyScattering {
+class ENDFTK_PYTHON_EXPORT DiscreteTwoBodyScattering {
 
 public:
 

--- a/src/ENDFtk/section/6/DiscreteTwoBodyScattering/LegendreCoefficients.hpp
+++ b/src/ENDFtk/section/6/DiscreteTwoBodyScattering/LegendreCoefficients.hpp
@@ -11,7 +11,7 @@
  *
  *  See ENDF102, section 6.2.4 for more information.
  */
-class LegendreCoefficients : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT LegendreCoefficients : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/6/DiscreteTwoBodyScattering/LegendreCoefficients/src/verifyLANG.hpp"

--- a/src/ENDFtk/section/6/DiscreteTwoBodyScattering/TabulatedDistribution.hpp
+++ b/src/ENDFtk/section/6/DiscreteTwoBodyScattering/TabulatedDistribution.hpp
@@ -11,7 +11,7 @@
  *
  *  See ENDF102, section 6.2.4 for more information.
  */
-class TabulatedDistribution : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT TabulatedDistribution : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/6/DiscreteTwoBodyScattering/TabulatedDistribution/src/verifyLANG.hpp"

--- a/src/ENDFtk/section/6/IsotropicDiscreteEmission.hpp
+++ b/src/ENDFtk/section/6/IsotropicDiscreteEmission.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 6.2.4 for more information.
  */
-class IsotropicDiscreteEmission : protected NoLawDataGiven {
+class ENDFTK_PYTHON_EXPORT IsotropicDiscreteEmission : protected NoLawDataGiven {
 
 public:
 

--- a/src/ENDFtk/section/6/LaboratoryAngleEnergy.hpp
+++ b/src/ENDFtk/section/6/LaboratoryAngleEnergy.hpp
@@ -9,7 +9,7 @@
  *
  *  See ENDF102, section 6.2.8 for more information.
  */
-class LaboratoryAngleEnergy {
+class ENDFTK_PYTHON_EXPORT LaboratoryAngleEnergy {
 public:
 
   #include "ENDFtk/section/6/LaboratoryAngleEnergy/EnergyDistribution.hpp"

--- a/src/ENDFtk/section/6/LaboratoryAngleEnergy/AngularDistribution.hpp
+++ b/src/ENDFtk/section/6/LaboratoryAngleEnergy/AngularDistribution.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 12.2.8 for more information.
  */
-class AngularDistribution :
+class ENDFTK_PYTHON_EXPORT AngularDistribution :
   protected InterpolationSequenceRecord< EnergyDistribution > {
 
 public:

--- a/src/ENDFtk/section/6/LaboratoryAngleEnergy/EnergyDistribution.hpp
+++ b/src/ENDFtk/section/6/LaboratoryAngleEnergy/EnergyDistribution.hpp
@@ -5,7 +5,7 @@
  *
  *  See ENDF102, section 12.2.8 for more information.
  */
-class EnergyDistribution : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT EnergyDistribution : protected TabulationRecord {
 
 public:
   /* constructor */

--- a/src/ENDFtk/section/6/Multiplicity.hpp
+++ b/src/ENDFtk/section/6/Multiplicity.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 6.2 for more information.
  */
-class Multiplicity : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT Multiplicity : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/6/NBodyPhaseSpace.hpp
+++ b/src/ENDFtk/section/6/NBodyPhaseSpace.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 6.2.5 for more information.
  */
-class NBodyPhaseSpace : protected ControlRecord {
+class ENDFTK_PYTHON_EXPORT NBodyPhaseSpace : protected ControlRecord {
 
 public:
   /* constructor */

--- a/src/ENDFtk/section/6/ReactionProduct.hpp
+++ b/src/ENDFtk/section/6/ReactionProduct.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 6.2 for more information.
  */
-class ReactionProduct {
+class ENDFTK_PYTHON_EXPORT ReactionProduct {
 
   /* fields */
   Multiplicity multiplicity_;

--- a/src/ENDFtk/section/6/Unknown.hpp
+++ b/src/ENDFtk/section/6/Unknown.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 6.2.1 for more information.
  */
-class Unknown : protected NoLawDataGiven {
+class ENDFTK_PYTHON_EXPORT Unknown : protected NoLawDataGiven {
 
 public:
 

--- a/src/ENDFtk/section/7/2.hpp
+++ b/src/ENDFtk/section/7/2.hpp
@@ -10,6 +10,7 @@
 #include "range/v3/view/concat.hpp"
 #include "range/v3/view/single.hpp"
 #include "range/v3/view/transform.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -21,7 +22,8 @@ namespace ENDFtk {
 namespace section{
 
   template<>
-  class Type< 7, 2 > : protected BaseWithoutMT< Type< 7, 2 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 7, 2 > : 
+    protected BaseWithoutMT< Type< 7, 2 > > {
 
     friend BaseWithoutMT< Type< 7, 2 > >;
 

--- a/src/ENDFtk/section/7/2/CoherentElastic.hpp
+++ b/src/ENDFtk/section/7/2/CoherentElastic.hpp
@@ -10,7 +10,7 @@
  *
  *  See ENDF102, section 7.2 for more information.
  */
-class CoherentElastic {
+class ENDFTK_PYTHON_EXPORT CoherentElastic {
 
   /* members */
   TabulationRecord principal_;

--- a/src/ENDFtk/section/7/2/IncoherentElastic.hpp
+++ b/src/ENDFtk/section/7/2/IncoherentElastic.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 7.3 for more information.
  */
-class IncoherentElastic : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT IncoherentElastic : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/7/2/MixedElastic.hpp
+++ b/src/ENDFtk/section/7/2/MixedElastic.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 7.4 for more information.
  */
-class MixedElastic {
+class ENDFTK_PYTHON_EXPORT MixedElastic {
 
   /* fields */
   CoherentElastic coherent_;

--- a/src/ENDFtk/section/7/4.hpp
+++ b/src/ENDFtk/section/7/4.hpp
@@ -15,6 +15,7 @@
 #include "range/v3/view/single.hpp"
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/transform.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -26,7 +27,8 @@ namespace ENDFtk {
 namespace section{
 
   template<>
-  class Type< 7, 4 > : protected BaseWithoutMT< Type< 7, 4 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 7, 4 > : 
+    protected BaseWithoutMT< Type< 7, 4 > > {
 
     friend BaseWithoutMT< Type< 7, 4 > >;
 

--- a/src/ENDFtk/section/7/4/AnalyticalFunctions.hpp
+++ b/src/ENDFtk/section/7/4/AnalyticalFunctions.hpp
@@ -12,7 +12,7 @@
  *
  *  See ENDF102, section 7.5 for more information.
  */
-class AnalyticalFunctions {
+class ENDFTK_PYTHON_EXPORT AnalyticalFunctions {
 
 public:
 

--- a/src/ENDFtk/section/7/4/EffectiveTemperature.hpp
+++ b/src/ENDFtk/section/7/4/EffectiveTemperature.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 7.5 for more information.
  */
-class EffectiveTemperature : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT EffectiveTemperature : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/7/4/ScatteringLawConstants.hpp
+++ b/src/ENDFtk/section/7/4/ScatteringLawConstants.hpp
@@ -11,7 +11,7 @@
  *
  *  See ENDF102, section 7.5 for more information.
  */
-class ScatteringLawConstants : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT ScatteringLawConstants : protected ListRecord {
 
   /* auxiliary functions */
   #include "ENDFtk/section/7/4/ScatteringLawConstants/src/generateList.hpp"

--- a/src/ENDFtk/section/7/4/TabulatedFunctions.hpp
+++ b/src/ENDFtk/section/7/4/TabulatedFunctions.hpp
@@ -11,7 +11,7 @@
  *
  *  See ENDF102, section 7.5 for more information.
  */
-class TabulatedFunctions {
+class ENDFTK_PYTHON_EXPORT TabulatedFunctions {
 
 public:
 

--- a/src/ENDFtk/section/7/451.hpp
+++ b/src/ENDFtk/section/7/451.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/section.hpp"
@@ -17,7 +18,8 @@ namespace ENDFtk {
 namespace section{
 
   template<>
-  class Type< 7, 451 > : protected BaseWithoutMT< Type< 7, 451 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 7, 451 > : 
+    protected BaseWithoutMT< Type< 7, 451 > > {
 
     friend BaseWithoutMT< Type< 7, 451 > >;
 

--- a/src/ENDFtk/section/8/454.hpp
+++ b/src/ENDFtk/section/8/454.hpp
@@ -5,6 +5,7 @@
 
 // other includes
 #include "range/v3/range/conversion.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
 #include "ENDFtk/section.hpp"
@@ -15,7 +16,8 @@ namespace ENDFtk {
 namespace section {
 
   template<>
-  class Type< 8, 454 > : protected BaseWithoutMT< Type< 8, 454 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 8, 454 > : 
+    protected BaseWithoutMT< Type< 8, 454 > > {
 
     friend BaseWithoutMT< Type< 8, 454 > >;
 

--- a/src/ENDFtk/section/8/457.hpp
+++ b/src/ENDFtk/section/8/457.hpp
@@ -9,6 +9,7 @@
 #include "range/v3/range/conversion.hpp"
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/join.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
@@ -20,7 +21,8 @@ namespace ENDFtk {
 namespace section{
 
   template<>
-  class Type< 8, 457 > : protected BaseWithoutMT< Type< 8, 457 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 8, 457 > : 
+    protected BaseWithoutMT< Type< 8, 457 > > {
 
     friend BaseWithoutMT< Type< 8, 457 > >;
 

--- a/src/ENDFtk/section/8/457/AverageDecayEnergies.hpp
+++ b/src/ENDFtk/section/8/457/AverageDecayEnergies.hpp
@@ -10,7 +10,7 @@
  *
  *  See ENDF102, section 8.4 for more information.
  */
-class AverageDecayEnergies : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT AverageDecayEnergies : protected ListRecord {
 
   /* members */
 

--- a/src/ENDFtk/section/8/457/ContinuousSpectrum.hpp
+++ b/src/ENDFtk/section/8/457/ContinuousSpectrum.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 8.4 for more information.
  */
-class ContinuousSpectrum : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT ContinuousSpectrum : protected TabulationRecord {
 
 public:
 

--- a/src/ENDFtk/section/8/457/DecayMode.hpp
+++ b/src/ENDFtk/section/8/457/DecayMode.hpp
@@ -8,7 +8,7 @@
  *
  *  See ENDF102, section 8.4 for more information.
  */
-class DecayMode {
+class ENDFTK_PYTHON_EXPORT DecayMode {
 
   /* members */
   double rtyp_;

--- a/src/ENDFtk/section/8/457/DecayModes.hpp
+++ b/src/ENDFtk/section/8/457/DecayModes.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 8.4 for more information.
  */
-class DecayModes : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT DecayModes : protected ListRecord {
 
   /* members */
 

--- a/src/ENDFtk/section/8/457/DecaySpectrum.hpp
+++ b/src/ENDFtk/section/8/457/DecaySpectrum.hpp
@@ -7,7 +7,7 @@
  *
  *  See ENDF102, section 8.4 for more information.
  */
-class DecaySpectrum {
+class ENDFTK_PYTHON_EXPORT DecaySpectrum {
 
 public:
 

--- a/src/ENDFtk/section/8/457/DiscreteSpectrum.hpp
+++ b/src/ENDFtk/section/8/457/DiscreteSpectrum.hpp
@@ -10,7 +10,7 @@
  *
  *  See ENDF102, section 8.4 for more information.
  */
-class DiscreteSpectrum : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT DiscreteSpectrum : protected ListRecord {
 
   /* members */
 

--- a/src/ENDFtk/section/8/459.hpp
+++ b/src/ENDFtk/section/8/459.hpp
@@ -5,6 +5,7 @@
 
 // other includes
 #include "range/v3/range/conversion.hpp"
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
 #include "ENDFtk/section.hpp"
@@ -15,7 +16,8 @@ namespace ENDFtk {
 namespace section {
 
   template<>
-  class Type< 8, 459 > : protected BaseWithoutMT< Type< 8, 459 > > {
+  class ENDFTK_PYTHON_EXPORT Type< 8, 459 > : 
+    protected BaseWithoutMT< Type< 8, 459 > > {
 
     friend BaseWithoutMT< Type< 8, 459 > >;
 

--- a/src/ENDFtk/section/8/FissionYieldData.hpp
+++ b/src/ENDFtk/section/8/FissionYieldData.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ListRecord.hpp"
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/drop_exactly.hpp"
@@ -24,7 +25,7 @@ namespace section{
    *
    *  See ENDF102, section 8.3 for more information.
    */
-  class FissionYieldData : protected ListRecord {
+  class ENDFTK_PYTHON_EXPORT FissionYieldData : protected ListRecord {
 
     /* auxiliary functions */
     #include "ENDFtk/section/8/FissionYieldData/src/verifySize.hpp"

--- a/src/ENDFtk/section/8/FissionYieldData/FissionProduct.hpp
+++ b/src/ENDFtk/section/8/FissionYieldData/FissionProduct.hpp
@@ -5,7 +5,7 @@
  *  See ENDF102, section 8.3 for more information.
  */
 template < typename Range >
-class FissionProduct {
+class ENDFTK_PYTHON_EXPORT FissionProduct {
 
   /* fields */
   Range chunk;

--- a/src/ENDFtk/section/9.hpp
+++ b/src/ENDFtk/section/9.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/readSequence.hpp"
@@ -20,7 +21,7 @@ namespace section {
    *  See ENDF102, section 9.2 for more information.
    */
   template<>
-  class Type< 9 > : protected Base {
+  class ENDFTK_PYTHON_EXPORT Type< 9 > : protected Base {
 
   public:
 

--- a/src/ENDFtk/section/9/ReactionProduct.hpp
+++ b/src/ENDFtk/section/9/ReactionProduct.hpp
@@ -4,7 +4,7 @@
  *
  *  See ENDF102, section 9.2 for more information.
  */
-class ReactionProduct : protected TabulationRecord {
+class ENDFTK_PYTHON_EXPORT ReactionProduct : protected TabulationRecord {
 
   /* auxiliary functions */
 

--- a/src/ENDFtk/section/CovariancePairs.hpp
+++ b/src/ENDFtk/section/CovariancePairs.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/stride.hpp"
@@ -19,7 +20,7 @@ namespace section{
  *
  *  See ENDF102, section 33.2 for more information.
  */
-class CovariancePairs : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT CovariancePairs : protected ListRecord {
 
   #include "ENDFtk/section/CovariancePairs/src/verifyLB.hpp"
   #include "ENDFtk/section/CovariancePairs/src/verifySize.hpp"

--- a/src/ENDFtk/section/DerivedRatioToStandard.hpp
+++ b/src/ENDFtk/section/DerivedRatioToStandard.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/stride.hpp"
 #include "ENDFtk/ControlRecord.hpp"
@@ -19,7 +20,7 @@ namespace section{
  *
  *  See ENDF102, section 33.2 for more information.
  */
-class DerivedRatioToStandard {
+class ENDFTK_PYTHON_EXPORT DerivedRatioToStandard {
 
    /* fields */
    int lty_;

--- a/src/ENDFtk/section/DerivedRedundant.hpp
+++ b/src/ENDFtk/section/DerivedRedundant.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/stride.hpp"
 #include "ENDFtk/ControlRecord.hpp"
@@ -19,7 +20,7 @@ namespace section{
  *
  *  See ENDF102, section 33.2 for more information.
  */
-class DerivedRedundant {
+class ENDFTK_PYTHON_EXPORT DerivedRedundant {
 
    /* fields */
    ListRecord list_;

--- a/src/ENDFtk/section/ReactionBlock.hpp
+++ b/src/ENDFtk/section/ReactionBlock.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/view/all.hpp"
 #include "ENDFtk/section/CovariancePairs.hpp"
 #include "ENDFtk/section/SquareMatrix.hpp"
@@ -29,7 +30,7 @@ namespace section{
  *
  *  See ENDF102, section 33.2 for more information.
  */
-class ReactionBlock {
+class ENDFTK_PYTHON_EXPORT ReactionBlock {
 
   /* fields */
   int xmf1_;

--- a/src/ENDFtk/section/RectangularMatrix.hpp
+++ b/src/ENDFtk/section/RectangularMatrix.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/range/conversion.hpp"
 #include "range/v3/view/concat.hpp"
 #include "range/v3/view/drop_exactly.hpp"
@@ -20,7 +21,7 @@ namespace section{
  *
  *  See ENDF102, section 33.2 for more information.
  */
-class RectangularMatrix : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT RectangularMatrix : protected ListRecord {
 
   #include "ENDFtk/section/RectangularMatrix/src/verifyLB.hpp"
   #include "ENDFtk/section/RectangularMatrix/src/verifySize.hpp"

--- a/src/ENDFtk/section/SquareMatrix.hpp
+++ b/src/ENDFtk/section/SquareMatrix.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "ENDFtk/macros.hpp"
 #include "range/v3/range/conversion.hpp"
 #include "range/v3/view/concat.hpp"
 #include "range/v3/view/drop_exactly.hpp"
@@ -20,7 +21,7 @@ namespace section{
  *
  *  See ENDF102, section 33.2 for more information.
  */
-class SquareMatrix : protected ListRecord {
+class ENDFTK_PYTHON_EXPORT SquareMatrix : protected ListRecord {
 
   #include "ENDFtk/section/SquareMatrix/src/verifyLB.hpp"
   #include "ENDFtk/section/SquareMatrix/src/verifySize.hpp"


### PR DESCRIPTION
This update does not add any additional functionality.

This update fixes the following issues:
  - A compilation issue in a unit test that still used the old catch-adapter (see issue #193).
  - Macros for pybind11 were added where required so that other pybind11 bond libraries can accept ENDFtk components as input arguments on the python side (e.g. covariance matrice blocks). This is currently limited to all ENDFtk section components.