### PR TITLE
Update/tools dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_dependent_option(
 cmake_dependent_option(
   ENDFtk.python
   "Build ENDFtk python bindings" ON
-  "NOT ${subproject} OR DEFINED requires.ENDFtk.python " OFF
+  "NOT ${subproject} OR DEFINED require.ENDFtk.python " OFF
 )
 
 ########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ target_include_directories( ENDFtk
 target_link_libraries( ENDFtk
     INTERFACE
       njoy::tools
-      disco
       range-v3
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_dependent_option(
 cmake_dependent_option(
   ENDFtk.python
   "Build ENDFtk python bindings" ON
-  "NOT ${subproject}" OFF
+  "NOT ${subproject} OR DEFINED requires.ENDFtk.python " OFF
 )
 
 ########################################################################
@@ -334,7 +334,9 @@ if( ENDFtk.python )
 
   list( APPEND ENDFtk_PYTHONPATH ${CMAKE_CURRENT_BINARY_DIR} )
 
-  include( cmake/unit_testing_python.cmake )
+  if( ENDFtk.tests )
+    include( cmake/unit_testing_python.cmake )
+  endif()
 
 endif()
 

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -7,7 +7,7 @@ include( FetchContent )
 
 FetchContent_Declare( tools
     GIT_REPOSITORY  https://github.com/njoy/tools
-    GIT_TAG         feature/disco
+    GIT_TAG         feature/python-views
     GIT_SHALLOW     TRUE
     )
 

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -7,7 +7,7 @@ include( FetchContent )
 
 FetchContent_Declare( tools
     GIT_REPOSITORY  https://github.com/njoy/tools
-    GIT_TAG         feature/python-views
+    GIT_TAG         v0.3.0
     GIT_SHALLOW     TRUE
     )
 

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -7,19 +7,13 @@ include( FetchContent )
 
 FetchContent_Declare( tools
     GIT_REPOSITORY  https://github.com/njoy/tools
-    GIT_TAG         v0.2.0
+    GIT_TAG         feature/disco
     GIT_SHALLOW     TRUE
     )
 
 FetchContent_Declare( Catch2
     GIT_REPOSITORY  https://github.com/catchorg/Catch2
     GIT_TAG         v3.3.2
-    GIT_SHALLOW     TRUE
-    )
-
-FetchContent_Declare( disco
-    GIT_REPOSITORY  https://github.com/njoy/disco
-    GIT_TAG         origin/master
     GIT_SHALLOW     TRUE
     )
 
@@ -39,6 +33,5 @@ FetchContent_Declare( pybind11
 
 FetchContent_MakeAvailable(
     tools
-    disco
     range-v3
     )

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -33,7 +33,7 @@ set( SPDLOG_BUILD_PIC CACHE INTERNAL BOOL ON )
 
 FetchContent_Declare( tools
     GIT_REPOSITORY  https://github.com/njoy/tools
-    GIT_TAG         8db01f66cd75a4ae61289fec7d6a58b562fb7913
+    GIT_TAG         14596b303de7413167f4f4c030e2923cabd3f2a3
     )
 
 #######################################################################

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -5,19 +5,14 @@ include( FetchContent )
 # Declare project dependencies
 #######################################################################
 
-FetchContent_Declare( catch-adapter
-    GIT_REPOSITORY  https://github.com/njoy/catch-adapter
-    GIT_TAG         fb84b82ebf7a4789aa43cea560680cf745c6ee4f
-    )
-
 FetchContent_Declare( Catch2
     GIT_REPOSITORY  https://github.com/catchorg/Catch2
     GIT_TAG         3f0283de7a9c43200033da996ff9093be3ac84dc # tag: v3.3.2
     )
 
-FetchContent_Declare( disco
-    GIT_REPOSITORY  https://github.com/njoy/disco
-    GIT_TAG         2606933a854bb0269c4ec37143e1236797e27838
+FetchContent_Declare( fast_float
+    GIT_REPOSITORY  https://github.com/fastfloat/fast_float
+    GIT_TAG         f476bc713fda06fbd34dc621b466745a574b3d4c # tag: v6.1.1
     )
 
 FetchContent_Declare( pybind11
@@ -38,7 +33,7 @@ set( SPDLOG_BUILD_PIC CACHE INTERNAL BOOL ON )
 
 FetchContent_Declare( tools
     GIT_REPOSITORY  https://github.com/njoy/tools
-    GIT_TAG         25c9273d05601a9644feea6d7539250bf1d1c0dc # tag: v0.2.0
+    GIT_TAG         8db01f66cd75a4ae61289fec7d6a58b562fb7913
     )
 
 #######################################################################
@@ -46,7 +41,7 @@ FetchContent_Declare( tools
 #######################################################################
 
 FetchContent_MakeAvailable(
-    disco
+    fast_float
     range-v3
     spdlog
     tools

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -33,7 +33,7 @@ set( SPDLOG_BUILD_PIC CACHE INTERNAL BOOL ON )
 
 FetchContent_Declare( tools
     GIT_REPOSITORY  https://github.com/njoy/tools
-    GIT_TAG         14596b303de7413167f4f4c030e2923cabd3f2a3
+    GIT_TAG         368dbd9bd44754de616c46ffed0f80d2d16d8360 # tag: v0.3.0
     )
 
 #######################################################################

--- a/src/ENDFtk/ControlRecord/src/print.hpp
+++ b/src/ENDFtk/ControlRecord/src/print.hpp
@@ -10,11 +10,13 @@
  */
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
+
+  using namespace njoy::tools;
   using Format = disco::Record< disco::ENDF, disco::ENDF,
                                 disco::Integer< 11 >, disco::Integer< 11 >,
                                 disco::Integer< 11 >, disco::Integer< 11 >,
                                 disco::Integer< 4 >, disco::Integer< 2>,
-                                disco::Integer< 3 >, disco::ColumnPosition<5> >;
+                                disco::Integer< 3 >, disco::Column<5> >;
   Format::write( it,
                  this->C1(), this->C2(),
                  this->L1(), this->L2(),

--- a/src/ENDFtk/DirectoryRecord/src/print.hpp
+++ b/src/ENDFtk/DirectoryRecord/src/print.hpp
@@ -11,10 +11,11 @@
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
 
+  using namespace njoy::tools;
   using Format = disco::Record< disco::Integer< 33 >, disco::Integer< 11 >,
                                 disco::Integer< 11 >, disco::Integer< 11 >,
                                 disco::Integer< 4 >, disco::Integer< 2 >,
-                                disco::Integer< 3 >, disco::ColumnPosition<5> >;
+                                disco::Integer< 3 >, disco::Column<5> >;
   Format::write( it, this->MF(), this->MT(),
                  this->NC(), this->MOD(), MAT, MF, MT );
 }

--- a/src/ENDFtk/ListRecord/src/print.hpp
+++ b/src/ENDFtk/ListRecord/src/print.hpp
@@ -10,12 +10,14 @@
  */
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
+
+  using namespace njoy::tools;
   {
     using Format = disco::Record< disco::ENDF, disco::ENDF,
                                   disco::Integer< 11 >, disco::Integer< 11 >,
                                   disco::Integer< 11 >, disco::Integer< 11 >,
                                   disco::Integer< 4 >, disco::Integer< 2 >,
-                                  disco::Integer< 3 >, disco::ColumnPosition<5> >;
+                                  disco::Integer< 3 >, disco::Column<5> >;
     Format::write( it,
                    this->C1(), this->C2(),
                    this->L1(), this->L2(),
@@ -26,7 +28,7 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
                                   disco::ENDF, disco::ENDF,
                                   disco::ENDF, disco::ENDF,
                                   disco::Integer< 4 >, disco::Integer< 2 >,
-                                  disco::Integer< 3 >, disco::ColumnPosition<5> >;
+                                  disco::Integer< 3 >, disco::Column<5> >;
 
     auto nFullLines = this->NPL() / 6;
     auto partialLineEntries = this->NPL() - nFullLines * 6;
@@ -47,11 +49,11 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
 
       auto blankEntries = 6 - partialLineEntries;
 
-      while ( blankEntries-- ){ disco::ColumnPosition< 11 >::write( it ); }
+      while ( blankEntries-- ){ disco::Column< 11 >::write( it ); }
 
       using Format =
         disco::Record< disco::Integer< 4 >, disco::Integer< 2 >,
-                       disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                       disco::Integer< 3 >, disco::Column< 5 > >;
 
       Format::write( it, MAT, MF, MT );
     }

--- a/src/ENDFtk/StructureDivision.hpp
+++ b/src/ENDFtk/StructureDivision.hpp
@@ -144,6 +144,7 @@ namespace ENDFtk {
     template< typename OutputIterator >
     void print( OutputIterator& it ) const {
 
+      using namespace njoy::tools;
       if ( this->isHead() ) {
 
         using Format = disco::Record< disco::ENDF, disco::ENDF,
@@ -151,7 +152,7 @@ namespace ENDFtk {
                                       disco::Integer< 11 >, disco::Integer< 11 >,
                                       disco::Integer< 4 >, disco::Integer< 2>,
                                       disco::Integer< 3 >,
-                                      disco::ColumnPosition<5> >;
+                                      disco::Column<5> >;
         Format::write( it, std::get< 0 >( this->base.fields ),
                            std::get< 1 >( this->base.fields ),
                            std::get< 2 >( this->base.fields ),
@@ -165,7 +166,7 @@ namespace ENDFtk {
         using Format = disco::Record< disco::Integer< 70 >,
                                       disco::Integer< 2 >,
                                       disco::Integer< 3 >,
-                                      disco::ColumnPosition<5> >;
+                                      disco::Column<5> >;
         Format::write( it, this->tail.MAT(), this->tail.MF(), this->tail.MT() );
       }
     }

--- a/src/ENDFtk/TabulationRecord/src/print.hpp
+++ b/src/ENDFtk/TabulationRecord/src/print.hpp
@@ -12,11 +12,13 @@ template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
   record::InterpolationBase::print( it, MAT, MF, MT );
 
+  using namespace njoy::tools;
+
   using Format = disco::Record< disco::ENDF, disco::ENDF,
                                 disco::ENDF, disco::ENDF,
                                 disco::ENDF, disco::ENDF,
                                 disco::Integer< 4 >, disco::Integer< 2 >,
-                                disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                                disco::Integer< 3 >, disco::Column< 5 > >;
 
   auto nFullLines = this->NP() / 3;
   auto partialLineEntries = this->NP() - nFullLines * 3;
@@ -37,11 +39,11 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
       ++x; ++y;
     }
 
-    while ( blankEntries-- ){ disco::ColumnPosition< 11 >::write( it ); }
+    while ( blankEntries-- ){ disco::Column< 11 >::write( it ); }
 
     using Format =
       disco::Record< disco::Integer< 4 >, disco::Integer< 2 >,
-                     disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                     disco::Integer< 3 >, disco::Column< 5 > >;
 
     Format::write( it, MAT, MF, MT );
   }

--- a/src/ENDFtk/TapeIdentification/src/print.hpp
+++ b/src/ENDFtk/TapeIdentification/src/print.hpp
@@ -10,8 +10,11 @@
  */
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
+
+  using namespace njoy::tools;
+
   using Format = disco::Record< disco::Character< 66 >,
                                 disco::Integer< 4 >, disco::Integer< 2 >,
-                                disco::Integer< 3 >, disco::ColumnPosition<5> >;
+                                disco::Integer< 3 >, disco::Column<5> >;
   Format::write( it, this->text(), MAT, MF, MT );
 }

--- a/src/ENDFtk/TextRecord/src/print.hpp
+++ b/src/ENDFtk/TextRecord/src/print.hpp
@@ -1,7 +1,10 @@
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
+
+  using namespace njoy::tools;
+
   using Format = disco::Record< disco::Character< 66 >,
                                 disco::Integer< 4 >, disco::Integer< 2 >,
-                                disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                                disco::Integer< 3 >, disco::Column< 5 > >;
   Format::write( it, this->text(), MAT, MF, MT );
 }

--- a/src/ENDFtk/record/Base.hpp
+++ b/src/ENDFtk/record/Base.hpp
@@ -5,6 +5,7 @@
 
 // other includes
 #include "tools/Log.hpp"
+#include "tools/disco/Record.hpp"
 #include "ENDFtk/record/helper.hpp"
 #include "ENDFtk/record/Character.hpp"
 #include "ENDFtk/record/Integer.hpp"
@@ -26,8 +27,8 @@ namespace record {
 
     /* convenience typedefs */
     using FieldTuple = std::tuple< typename Fields::Type... >;
-    using Format = disco::Record< typename Fields::Parser...,
-                                  disco::RetainCarriage >;
+    using Format = njoy::tools::disco::Record< typename Fields::Parser...,
+                                               njoy::tools::disco::RetainCarriage >;
 
     template< int Index >
     using ShouldRecurse =

--- a/src/ENDFtk/record/Character.hpp
+++ b/src/ENDFtk/record/Character.hpp
@@ -4,7 +4,7 @@
 // system includes
 
 // other includes
-#include "disco.hpp"
+#include "tools/disco/Character.hpp"
 #include "ENDFtk/record/helper.hpp"
 
 namespace njoy {
@@ -15,7 +15,7 @@ namespace record {
   struct Character {
     static constexpr std::size_t width = w;
     using Type = std::string;
-    using Parser = disco::Character< width >;
+    using Parser = njoy::tools::disco::Character< width >;
 
     static constexpr const Type& defaultValue = helper::defaultString< w >;
   };

--- a/src/ENDFtk/record/Integer.hpp
+++ b/src/ENDFtk/record/Integer.hpp
@@ -4,7 +4,7 @@
 // system includes
 
 // other includes
-#include "disco.hpp"
+#include "tools/disco/Integer.hpp"
 
 namespace njoy {
 namespace ENDFtk {
@@ -14,7 +14,7 @@ namespace record {
   struct Integer{
     static constexpr std::size_t width = w;
     using Type = long;
-    using Parser = disco::Integer< width >;
+    using Parser = njoy::tools::disco::Integer< width >;
 
     static constexpr Type defaultValue = 0;
   };

--- a/src/ENDFtk/record/IntegerBase/src/print.hpp
+++ b/src/ENDFtk/record/IntegerBase/src/print.hpp
@@ -11,10 +11,12 @@
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
 
+  using namespace njoy::tools;
+
   record::Integer< 5 >::Parser::write( this->I(), it );
   record::Integer< 5 >::Parser::write( this->J(), it );
 
-  if ( NDIGIT != 6 ) { disco::ColumnPosition< 1 >::write( it ); };
+  if ( NDIGIT != 6 ) { disco::Column< 1 >::write( it ); };
 
   for ( auto value : this->K() ) {
 
@@ -23,18 +25,18 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
 
   switch ( NDIGIT ) {
 
-    case 2: { disco::ColumnPosition< 1 >::write( it ); break; }
-    case 3: { disco::ColumnPosition< 3 >::write( it ); break; }
-    case 5: { disco::ColumnPosition< 1 >::write( it ); break; }
+    case 2: { disco::Column< 1 >::write( it ); break; }
+    case 3: { disco::Column< 3 >::write( it ); break; }
+    case 5: { disco::Column< 1 >::write( it ); break; }
     default: { /* unreachable */ break; }
   }
 
   int blankEntries = N - this->K().size();
-  while ( blankEntries-- ){ disco::ColumnPosition< NDIGIT + 1 >::write( it ); }
+  while ( blankEntries-- ){ disco::Column< NDIGIT + 1 >::write( it ); }
 
   using Format =
     disco::Record< disco::Integer< 4 >, disco::Integer< 2 >,
-                   disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                   disco::Integer< 3 >, disco::Column< 5 > >;
 
   Format::write( it, MAT, MF, MT );
 }

--- a/src/ENDFtk/record/InterpolationBase.hpp
+++ b/src/ENDFtk/record/InterpolationBase.hpp
@@ -5,6 +5,10 @@
 #include <vector>
 
 // other includes
+#include "tools/disco/Integer.hpp"
+#include "tools/disco/ENDF.hpp"
+#include "tools/disco/Column.hpp"
+#include "tools/disco/Record.hpp"
 #include "range/v3/view/all.hpp"
 #include "ENDFtk/record/Base.hpp"
 #include "ENDFtk/record/Integer.hpp"

--- a/src/ENDFtk/record/InterpolationBase/src/print.hpp
+++ b/src/ENDFtk/record/InterpolationBase/src/print.hpp
@@ -1,11 +1,14 @@
 template< typename OutputIterator >
 void print( OutputIterator& it, int MAT, int MF, int MT ) const {
+
+  using namespace njoy::tools;
+
   {
     using Format = disco::Record< disco::ENDF, disco::ENDF,
                                   disco::Integer< 11 >, disco::Integer< 11 >,
                                   disco::Integer< 11 >, disco::Integer< 11 >,
                                   disco::Integer< 4 >, disco::Integer< 2 >,
-                                  disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                                  disco::Integer< 3 >, disco::Column< 5 > >;
     Format::write( it,
                    this->C1(), this->C2(),
                    this->L1(), this->L2(),
@@ -17,14 +20,14 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
                                   disco::Integer< 11 >, disco::Integer< 11 >,
                                   disco::Integer< 11 >, disco::Integer< 11 >,
                                   disco::Integer< 4 >, disco::Integer< 2 >,
-                                  disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                                  disco::Integer< 3 >, disco::Column< 5 > >;
 
     auto nFullLines = this->NR() / 3;
     auto partialLineEntries = this->NR() - nFullLines * 3;
 
     auto boundary = this->boundaries().begin();
     auto interpolant = this->interpolants().begin();
-    
+
     while ( nFullLines-- ){
       Format::write( it,
                      boundary[0], interpolant[0],
@@ -33,7 +36,7 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
                      MAT, MF, MT );
       boundary += 3; interpolant += 3;
     }
-        
+
     if ( partialLineEntries ){
       auto blankEntries = 2 * ( 3 - partialLineEntries );
       while ( partialLineEntries-- ){
@@ -41,15 +44,14 @@ void print( OutputIterator& it, int MAT, int MF, int MT ) const {
         disco::Integer<11>::write( *interpolant, it );
         ++boundary; ++interpolant;
       }
-      
-      while ( blankEntries-- ){ disco::ColumnPosition< 11 >::write( it ); }
+
+      while ( blankEntries-- ){ disco::Column< 11 >::write( it ); }
 
       using Format =
         disco::Record< disco::Integer< 4 >, disco::Integer< 2 >,
-                       disco::Integer< 3 >, disco::ColumnPosition< 5 > >;
+                       disco::Integer< 3 >, disco::Column< 5 > >;
 
       Format::write( it, MAT, MF, MT );
-    } 
-  } 
+    }
+  }
 }
-

--- a/src/ENDFtk/record/Real.hpp
+++ b/src/ENDFtk/record/Real.hpp
@@ -4,7 +4,7 @@
 // system includes
 
 // other includes
-#include "disco.hpp"
+#include "tools/disco/ENDF.hpp"
 
 namespace njoy {
 namespace ENDFtk {
@@ -13,8 +13,8 @@ namespace record {
   struct Real {
     static constexpr std::size_t width = 11;
     using Type = double;
-    using Parser = disco::ENDF;
-  
+    using Parser = njoy::tools::disco::ENDF;
+
     static constexpr Type defaultValue = 0.0;
   };
 

--- a/src/ENDFtk/record/Tail.hpp
+++ b/src/ENDFtk/record/Tail.hpp
@@ -5,7 +5,8 @@
 #include <string>
 
 // other includes
-#include "disco.hpp"
+#include "tools/disco/Integer.hpp"
+#include "tools/disco/Record.hpp"
 #include "tools/Log.hpp"
 
 namespace njoy {
@@ -20,10 +21,11 @@ namespace record {
 
   public:
 
-    using Format = disco::Record< disco::Integer< 4 >,
-                                  disco::Integer< 2 >,
-                                  disco::Integer< 3 >,
-                                  disco::Integer< 5 > >;
+    using Format = njoy::tools::disco::Record<
+                       njoy::tools::disco::Integer< 4 >,
+                       njoy::tools::disco::Integer< 2 >,
+                       njoy::tools::disco::Integer< 3 >,
+                       njoy::tools::disco::Integer< 5 > >;
 
     /* fields */
     std::array< int, 3 > fields;

--- a/src/ENDFtk/record/TailVerifying.hpp
+++ b/src/ENDFtk/record/TailVerifying.hpp
@@ -5,7 +5,6 @@
 
 // other includes
 #include "tools/Log.hpp"
-#include "disco.hpp"
 #include "ENDFtk/record/helper.hpp"
 #include "ENDFtk/record/Integer.hpp"
 #include "ENDFtk/record/Real.hpp"

--- a/src/ENDFtk/record/Zipper/src/Zipped.hpp
+++ b/src/ENDFtk/record/Zipper/src/Zipped.hpp
@@ -2,7 +2,7 @@ template< typename... ENDFTypes  >
 struct Zipped {
   static constexpr std::size_t
   tupleWidth = helper::sum< ENDFTypes::width... >();
-    
+
   static_assert( tupleWidth < 66, "too many entries on line" );
 
   static constexpr std::size_t entriesPerTuple = sizeof...( ENDFTypes );
@@ -10,25 +10,26 @@ struct Zipped {
 
   static constexpr std::size_t
   entriesPerRecord = tuplesPerRecord * entriesPerTuple;
-    
+
   static const std::size_t nPad = 66 % tupleWidth;
 
   static constexpr auto tupleIndices =
     std::make_index_sequence< entriesPerTuple >();
-    
+
   /**
-   * @brief 
-   * This is dark magic to expand the parameter pack a number of times equal 
+   * @brief
+   * This is dark magic to expand the parameter pack a number of times equal
    * to the tuplesPerRecord class variable
    */
   template< std::size_t... indices >
   static decltype(auto)
     expand( std::index_sequence< indices... > ){
-    return disco::Record
+    return njoy::tools::disco::Record
       < typename std::tuple_element
         < indices % entriesPerTuple,
           std::tuple< typename ENDFTypes::Parser... > >::type... ,
-        disco::ColumnPosition< nPad >, disco::RetainCarriage >();
+        njoy::tools::disco::Column< nPad >,
+        njoy::tools::disco::RetainCarriage >();
   }
 
   using Format =
@@ -38,9 +39,10 @@ struct Zipped {
   using Type =
     typename std::tuple_element
     < index, std::tuple< typename ENDFTypes::Type... > >::type;
-    
+
   using TupleFormat =
-    disco::Record< typename ENDFTypes::Parser..., disco::RetainCarriage >;
+    njoy::tools::disco::Record< typename ENDFTypes::Parser...,
+                                njoy::tools::disco::RetainCarriage >;
 
   static const std::tuple< typename ENDFTypes::Type... >&
   defaultTuple(){

--- a/src/ENDFtk/record/Zipper/src/readPartialLine.hpp
+++ b/src/ENDFtk/record/Zipper/src/readPartialLine.hpp
@@ -6,14 +6,16 @@ readPartialLine
   long& lineNumber, int MAT, int MF, int MT,
   std::index_sequence< indices... > ){
 
+  using namespace njoy::tools;
+
 //auto increment = []( uint64_t offset, auto& iterator ){ iterator+= offset; };
-  
+
   for ( uint64_t offset = 0; offset < nEntries; ++offset ){
     Zip::TupleFormat::read
       ( it, end, std::get< indices >( iteratorTuple )[offset]... );
   }
-  
-  auto remainingEntries = Zip::tuplesPerRecord - nEntries;    
+
+  auto remainingEntries = Zip::tuplesPerRecord - nEntries;
   std::tuple< typename Zip:: template Type< indices >... > leftovers;
 
   while ( remainingEntries-- ){
@@ -23,12 +25,11 @@ readPartialLine
       throw std::exception();
     }
   }
-  
+
   using Gap = disco::Record
-              < disco::ColumnPosition< Zip::nPad >, disco::RetainCarriage >;
+              < disco::Column< Zip::nPad >, disco::RetainCarriage >;
 
   Gap::read( it, end );
 
   verifyTail( it, end, lineNumber, MAT, MF, MT );
 }
-


### PR DESCRIPTION
This removes disco as a dependency from ENDFtk and replaces it with a disco rewrite in the tools library. This update solves the issue where 2.000+0 gets read as 1.999999999.

The interface has undergone minimal changes so the impact of this update is extremely small.

As a side note: the tools library updates that introduced disco are still under review so the dependency is just pointing to a specific commit of the feature/python-views in tools. I will not merge this until we have tagged a tools release and point to that instead. That will just change the dependency files so we can already proceed with review.
