### PR TITLE
Feature/cleaner interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( DEFINED PROJECT_NAME )
 endif()
 
 project( ENDFtk
-  VERSION 1.1.0
+  VERSION 1.1.1
   LANGUAGES CXX
 )
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,12 @@
 # Release Notes&mdash;ENDFtk
 Given here are some release notes for ENDFtk.
 
+## [ENDFtk v1.1.1](https://github.com/njoy/ENDFtk/pull/xxx)
+This update removes a few interface functions that are unused:
+  - the regions() and pairs() interface functions on the TAB1 record
+
+The removal of these interface functions has no impact on the Python interface as these interface functions were not included on the Python side.
+
 ## [ENDFtk v1.1.0](https://github.com/njoy/ENDFtk/pull/198)
 This update adds additional interface functions to complete the human readable and ENDF speak interface for many objects:
   - the NBT() and INT() interface functions to complement the boundaries() and interpolants() functions already present in TAB1 and TAB2 style components

--- a/src/ENDFtk/TabulationRecord.hpp
+++ b/src/ENDFtk/TabulationRecord.hpp
@@ -7,10 +7,6 @@
 // other includes
 #include "tools/Log.hpp"
 #include "range/v3/view/all.hpp"
-#include "range/v3/view/iota.hpp"
-#include "range/v3/view/subrange.hpp"
-#include "range/v3/view/transform.hpp"
-#include "range/v3/view/zip.hpp"
 #include "ENDFtk/record.hpp"
 
 namespace njoy {
@@ -37,20 +33,6 @@ namespace ENDFtk {
     #include "ENDFtk/TabulationRecord/src/verifyXValuesAreSorted.hpp"
     #include "ENDFtk/TabulationRecord/src/verifyNP.hpp"
     #include "ENDFtk/TabulationRecord/src/readPairs.hpp"
-
-  protected:
-
-    auto regions( size_t index ) const {
-      const auto left = index ? this->boundaries()[ index - 1 ] - 1 : 0;
-      const auto right = this->boundaries()[ index ];
-      return
-        std::make_pair( ranges::make_subrange
-                        ( this->xValues.begin() + left,
-                          this->xValues.begin() + right ),
-                        ranges::make_subrange
-                        ( this->yValues.begin() + left,
-                          this->yValues.begin() + right ) );
-    }
 
   public:
 
@@ -92,29 +74,10 @@ namespace ENDFtk {
       return ranges::cpp20::views::all( this->yValues );
     }
 
-    /**
-     *  @brief Return the x,y pairs in the table
-     */
-    auto pairs() const {
-
-      return ranges::views::zip( this->xValues, this->yValues );
-    }
-
     using InterpolationBase::INT;
     using InterpolationBase::NBT;
     using InterpolationBase::interpolants;
     using InterpolationBase::boundaries;
-
-    /**
-     *  @brief Return the interpolation regions
-     */
-    auto regions() const {
-
-      return
-        ranges::views::iota( 0ul, this->boundaries().size() )
-        | ranges::cpp20::views::transform(
-            [this ]( int i ){ return this->regions(i); } );
-    }
 
     /**
      *  @brief Equality operator

--- a/src/ENDFtk/TabulationRecord/test/TabulationRecord.test.cpp
+++ b/src/ENDFtk/TabulationRecord/test/TabulationRecord.test.cpp
@@ -390,58 +390,6 @@ void verifyChunk( const TabulationRecord& chunk ) {
   CHECK_THAT(  9., WithinRel( chunk.y()[6] ) );
   CHECK_THAT( 10., WithinRel( chunk.y()[7] ) );
 
-  auto regions = chunk.regions();
-  CHECK( 4 == regions.size() );
-  CHECK( 4 == regions[0].first.size() );
-  CHECK( 4 == regions[0].second.size() );
-  CHECK( 2 == regions[1].first.size() );
-  CHECK( 2 == regions[1].second.size() );
-  CHECK( 2 == regions[2].first.size() );
-  CHECK( 2 == regions[2].second.size() );
-  CHECK( 3 == regions[3].first.size() );
-  CHECK( 3 == regions[3].second.size() );
-  CHECK_THAT(  1., WithinRel( regions[0].first[0] ) );
-  CHECK_THAT(  2., WithinRel( regions[0].first[1] ) );
-  CHECK_THAT(  3., WithinRel( regions[0].first[2] ) );
-  CHECK_THAT(  4., WithinRel( regions[0].first[3] ) );
-  CHECK_THAT(  4., WithinRel( regions[1].first[0] ) );
-  CHECK_THAT(  5., WithinRel( regions[1].first[1] ) );
-  CHECK_THAT(  5., WithinRel( regions[2].first[0] ) );
-  CHECK_THAT(  6., WithinRel( regions[2].first[1] ) );
-  CHECK_THAT(  6., WithinRel( regions[3].first[0] ) );
-  CHECK_THAT(  7., WithinRel( regions[3].first[1] ) );
-  CHECK_THAT(  8., WithinRel( regions[3].first[2] ) );
-  CHECK_THAT(  3., WithinRel( regions[0].second[0] ) );
-  CHECK_THAT(  4., WithinRel( regions[0].second[1] ) );
-  CHECK_THAT(  5., WithinRel( regions[0].second[2] ) );
-  CHECK_THAT(  6., WithinRel( regions[0].second[3] ) );
-  CHECK_THAT(  6., WithinRel( regions[1].second[0] ) );
-  CHECK_THAT(  7., WithinRel( regions[1].second[1] ) );
-  CHECK_THAT(  7., WithinRel( regions[2].second[0] ) );
-  CHECK_THAT(  8., WithinRel( regions[2].second[1] ) );
-  CHECK_THAT(  8., WithinRel( regions[3].second[0] ) );
-  CHECK_THAT(  9., WithinRel( regions[3].second[1] ) );
-  CHECK_THAT( 10., WithinRel( regions[3].second[2] ) );
-
-  auto pairs = chunk.pairs();
-  CHECK( 8 == pairs.size() );
-  CHECK_THAT(  1., WithinRel( pairs[0].first ) );
-  CHECK_THAT(  2., WithinRel( pairs[1].first ) );
-  CHECK_THAT(  3., WithinRel( pairs[2].first ) );
-  CHECK_THAT(  4., WithinRel( pairs[3].first ) );
-  CHECK_THAT(  5., WithinRel( pairs[4].first ) );
-  CHECK_THAT(  6., WithinRel( pairs[5].first ) );
-  CHECK_THAT(  7., WithinRel( pairs[6].first ) );
-  CHECK_THAT(  8., WithinRel( pairs[7].first ) );
-  CHECK_THAT(  3., WithinRel( pairs[0].second ) );
-  CHECK_THAT(  4., WithinRel( pairs[1].second ) );
-  CHECK_THAT(  5., WithinRel( pairs[2].second ) );
-  CHECK_THAT(  6., WithinRel( pairs[3].second ) );
-  CHECK_THAT(  7., WithinRel( pairs[4].second ) );
-  CHECK_THAT(  8., WithinRel( pairs[5].second ) );
-  CHECK_THAT(  9., WithinRel( pairs[6].second ) );
-  CHECK_THAT( 10., WithinRel( pairs[7].second ) );
-
   CHECK( 6 == chunk.NC() );
 }
 

--- a/src/ENDFtk/section/1/455.hpp
+++ b/src/ENDFtk/section/1/455.hpp
@@ -14,6 +14,7 @@
 #include "ENDFtk/section.hpp"
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/drop_exactly.hpp"
+#include "range/v3/view/transform.hpp"
 
 #include "ENDFtk/section/1/PolynomialMultiplicity.hpp"
 #include "ENDFtk/section/1/TabulatedMultiplicity.hpp"

--- a/src/ENDFtk/section/1/458.hpp
+++ b/src/ENDFtk/section/1/458.hpp
@@ -12,6 +12,8 @@
 #include "ENDFtk/ListRecord.hpp"
 #include "ENDFtk/TabulationRecord.hpp"
 #include "ENDFtk/section.hpp"
+#include "range/v3/view/iota.hpp"
+#include "range/v3/view/transform.hpp"
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/stride.hpp"

--- a/src/ENDFtk/section/10/ReactionProduct.hpp
+++ b/src/ENDFtk/section/10/ReactionProduct.hpp
@@ -85,7 +85,6 @@ public:
   using TabulationRecord::boundaries;
   using TabulationRecord::x;
   using TabulationRecord::y;
-  using TabulationRecord::regions;
   using TabulationRecord::NC;
   using TabulationRecord::print;
 };

--- a/src/ENDFtk/section/12.hpp
+++ b/src/ENDFtk/section/12.hpp
@@ -8,6 +8,7 @@
 // other includes
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/join.hpp"
+#include "range/v3/view/transform.hpp"
 #include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"

--- a/src/ENDFtk/section/12/PartialMultiplicity.hpp
+++ b/src/ENDFtk/section/12/PartialMultiplicity.hpp
@@ -85,7 +85,6 @@ public:
   using TabulationRecord::boundaries;
   using TabulationRecord::x;
   using TabulationRecord::y;
-  using TabulationRecord::regions;
   using TabulationRecord::NC;
   using TabulationRecord::print;
 };

--- a/src/ENDFtk/section/14.hpp
+++ b/src/ENDFtk/section/14.hpp
@@ -6,6 +6,7 @@
 
 // other includes
 #include "range/v3/algorithm/count_if.hpp"
+#include "range/v3/view/transform.hpp"
 #include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"

--- a/src/ENDFtk/section/2/151.hpp
+++ b/src/ENDFtk/section/2/151.hpp
@@ -11,6 +11,8 @@
 #include "range/v3/algorithm/find.hpp"
 #include "range/v3/range/conversion.hpp"
 #include "range/v3/view/all.hpp"
+#include "range/v3/view/iota.hpp"
+#include "range/v3/view/transform.hpp"
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/repeat_n.hpp"

--- a/src/ENDFtk/section/26.hpp
+++ b/src/ENDFtk/section/26.hpp
@@ -14,6 +14,8 @@
 #include "range/v3/view/single.hpp"
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/tail.hpp"
+#include "range/v3/view/zip.hpp"
+#include "range/v3/view/transform.hpp"
 #include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"

--- a/src/ENDFtk/section/4.hpp
+++ b/src/ENDFtk/section/4.hpp
@@ -10,6 +10,7 @@
 #include "range/v3/view/transform.hpp"
 #include "range/v3/view/empty.hpp"
 #include "range/v3/view/any_view.hpp"
+#include "range/v3/view/transform.hpp"
 #include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"

--- a/src/ENDFtk/section/7/4.hpp
+++ b/src/ENDFtk/section/7/4.hpp
@@ -15,6 +15,8 @@
 #include "range/v3/view/single.hpp"
 #include "range/v3/view/stride.hpp"
 #include "range/v3/view/transform.hpp"
+#include "range/v3/view/transform.hpp"
+#include "range/v3/view/zip.hpp"
 #include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
@@ -27,7 +29,7 @@ namespace ENDFtk {
 namespace section{
 
   template<>
-  class ENDFTK_PYTHON_EXPORT Type< 7, 4 > : 
+  class ENDFTK_PYTHON_EXPORT Type< 7, 4 > :
     protected BaseWithoutMT< Type< 7, 4 > > {
 
     friend BaseWithoutMT< Type< 7, 4 > >;

--- a/src/ENDFtk/section/8/457.hpp
+++ b/src/ENDFtk/section/8/457.hpp
@@ -9,6 +9,7 @@
 #include "range/v3/range/conversion.hpp"
 #include "range/v3/view/chunk.hpp"
 #include "range/v3/view/join.hpp"
+#include "range/v3/view/transform.hpp"
 #include "ENDFtk/macros.hpp"
 #include "ENDFtk/ControlRecord.hpp"
 #include "ENDFtk/ListRecord.hpp"
@@ -21,7 +22,7 @@ namespace ENDFtk {
 namespace section{
 
   template<>
-  class ENDFTK_PYTHON_EXPORT Type< 8, 457 > : 
+  class ENDFTK_PYTHON_EXPORT Type< 8, 457 > :
     protected BaseWithoutMT< Type< 8, 457 > > {
 
     friend BaseWithoutMT< Type< 8, 457 > >;

--- a/src/ENDFtk/section/9/ReactionProduct.hpp
+++ b/src/ENDFtk/section/9/ReactionProduct.hpp
@@ -85,7 +85,6 @@ public:
   using TabulationRecord::boundaries;
   using TabulationRecord::x;
   using TabulationRecord::y;
-  using TabulationRecord::regions;
   using TabulationRecord::NC;
   using TabulationRecord::print;
 };


### PR DESCRIPTION
This update removes a few interface functions that are unused and that I wanted to remove to make the removal of range-v3 a bit simpler:
  - the regions() and pairs() interface functions on the TAB1 record

The removal of these interface functions has no impact on the Python interface as these interface functions were not included on the Python side.