### PR TITLE
Feature/map to list

### DIFF
--- a/python/src/ENDFtk.python.cpp
+++ b/python/src/ENDFtk.python.cpp
@@ -72,6 +72,9 @@ PYBIND11_MODULE( ENDFtk, module ) {
 
   // wrap some basic recurring views
   // none of these are supposed to be created directly by the user
+  wrapBasicBidirectionalAnyViewOf< int >(
+      viewmodule,
+      "any_view< int, bidirectional >" );
   wrapBasicRandomAccessAnyViewOf< double >(
       viewmodule,
       "any_view< double, random_access >" );

--- a/python/src/tree/File.python.cpp
+++ b/python/src/tree/File.python.cpp
@@ -16,13 +16,13 @@ void wrapTreeFile( python::module& module, python::module& viewmodule ) {
   // type aliases
   using File = njoy::ENDFtk::tree::File;
   using Section = njoy::ENDFtk::tree::Section;
-  using SectionRange = BidirectionalAnyView< Section >;
+  using SectionRange = RandomAccessAnyView< Section >;
 
   // wrap views created by this tree component
   // none of these are supposed to be created directly by the user
-  wrapBidirectionalAnyViewOf< Section >(
+  wrapRandomAccessAnyViewOf< Section >(
       viewmodule,
-      "any_view< tree::Section, bidirectional >" );
+      "any_view< tree::Section, random_access >" );
 
   // create the tree component
   python::class_< File > tree(

--- a/python/src/tree/File.python.cpp
+++ b/python/src/tree/File.python.cpp
@@ -4,7 +4,6 @@
 
 // local includes
 #include "ENDFtk/tree/Tape.hpp"
-#include "range/v3/range/operations.hpp"
 #include "views.hpp"
 #include "variants.hpp"
 
@@ -16,13 +15,13 @@ void wrapTreeFile( python::module& module, python::module& viewmodule ) {
   // type aliases
   using File = njoy::ENDFtk::tree::File;
   using Section = njoy::ENDFtk::tree::Section;
-  using SectionRange = RandomAccessAnyView< Section >;
+  using SectionRange = BidirectionalAnyView< Section >;
 
   // wrap views created by this tree component
   // none of these are supposed to be created directly by the user
-  wrapRandomAccessAnyViewOf< Section >(
+  wrapBidirectionalAnyViewOf< Section >(
       viewmodule,
-      "any_view< tree::Section, random_access >" );
+      "any_view< tree::Section, bidirectional >" );
 
   // create the tree component
   python::class_< File > tree(
@@ -98,8 +97,8 @@ void wrapTreeFile( python::module& module, python::module& viewmodule ) {
   .def_property_readonly(
 
     "section_numbers",
-    [] ( const File& self ) -> std::vector< int >
-       { return ranges::to< std::vector< int > >( self.sectionNumbers() ); },
+    [] ( const File& self ) -> IntList
+       { return self.sectionNumbers(); },
     "All section numbers in the file"
   )
   .def_property_readonly(

--- a/python/src/tree/Material.python.cpp
+++ b/python/src/tree/Material.python.cpp
@@ -111,8 +111,8 @@ void wrapTreeMaterial( python::module& module, python::module& viewmodule ) {
   .def_property_readonly(
 
     "file_numbers",
-    [] ( const Material& self ) -> std::vector< int >
-       { return ranges::to< std::vector< int > >( self.fileNumbers() ); },
+    [] ( const Material& self ) -> IntList
+       { return self.fileNumbers(); },
     "All file numbers in the material"
   )
   .def_property_readonly(

--- a/python/src/views.hpp
+++ b/python/src/views.hpp
@@ -51,6 +51,7 @@ using RandomAccessAnyView = BasicRandomAccessAnyView< RefWrapper< Element > >;
 /**
  *  @brief Some recurring basic views
  */
+using IntList = BasicBidirectionalAnyView< int >;
 using DoubleRange = BasicRandomAccessAnyView< double >;
 using LongRange = BasicRandomAccessAnyView< long >;
 using IntRange = BasicRandomAccessAnyView< int >;

--- a/python/test/tree/Test_ENDFtk_Tree_Tape.py
+++ b/python/test/tree/Test_ENDFtk_Tree_Tape.py
@@ -37,7 +37,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 1, file.MF )
                 self.assertEqual( 1, file.file_number )
 
-                self.assertEqual( [ 451 ], file.section_numbers )
+                self.assertEqual( [ 451 ], file.section_numbers.to_list() )
                 self.assertEqual( [ 451 ],
                                   [ section.MT for section in file.sections ] )
 
@@ -61,7 +61,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 2, file.MF )
                 self.assertEqual( 2, file.file_number )
 
-                self.assertEqual( [ 151 ], file.section_numbers )
+                self.assertEqual( [ 151 ], file.section_numbers.to_list() )
                 self.assertEqual( [ 151 ],
                                   [ section.MT for section in file.sections ] )
 
@@ -85,7 +85,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 3, file.MF )
                 self.assertEqual( 3, file.file_number )
 
-                self.assertEqual( [ 1, 2, 102 ], file.section_numbers )
+                self.assertEqual( [ 1, 2, 102 ], file.section_numbers.to_list() )
                 self.assertEqual( [ 1, 2, 102 ],
                                   [ section.MT for section in file.sections ] )
 
@@ -109,7 +109,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 4, file.MF )
                 self.assertEqual( 4, file.file_number )
 
-                self.assertEqual( [ 2 ], file.section_numbers )
+                self.assertEqual( [ 2 ], file.section_numbers.to_list() )
                 self.assertEqual( [ 2 ],
                                   [ section.MT for section in file.sections ] )
 
@@ -133,7 +133,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 6, file.MF )
                 self.assertEqual( 6, file.file_number )
 
-                self.assertEqual( [ 102 ], file.section_numbers )
+                self.assertEqual( [ 102 ], file.section_numbers.to_list() )
                 self.assertEqual( [ 102 ],
                                   [ section.MT for section in file.sections ] )
 
@@ -157,7 +157,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 33, file.MF )
                 self.assertEqual( 33, file.file_number )
 
-                self.assertEqual( [ 1, 2, 102 ], file.section_numbers )
+                self.assertEqual( [ 1, 2, 102 ], file.section_numbers.to_list() )
                 self.assertEqual( [ 1, 2, 102 ],
                                   [ section.MT for section in file.sections ] )
 
@@ -179,7 +179,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
                 self.assertEqual( 125, material.MAT )
                 self.assertEqual( 125, material.material_number )
 
-                self.assertEqual( [ 1, 2, 3, 4, 6, 33 ], material.file_numbers )
+                self.assertEqual( [ 1, 2, 3, 4, 6, 33 ], material.file_numbers.to_list() )
                 self.assertEqual( [ 1, 2, 3, 4, 6, 33 ],
                                   [ file.MF for file in material.files ] )
 
@@ -289,44 +289,44 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
 
         # remove a file from a material
         material.remove( 2 )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers.to_list() )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers.to_list() )
 
         # remove a section from a material
         material.remove( 3, 2 )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers )
-        self.assertEqual( [ 1, 102 ], file.section_numbers )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers )
-        self.assertEqual( [ 1, 102 ], tape.materials.front().file(3).section_numbers )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers.to_list() )
+        self.assertEqual( [ 1, 102 ], file.section_numbers.to_list() )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers.to_list() )
+        self.assertEqual( [ 1, 102 ], tape.materials.front().file(3).section_numbers.to_list() )
 
         # remove a section from a file
         file.remove( 102 )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers )
-        self.assertEqual( [ 1 ], file.section_numbers )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers )
-        self.assertEqual( [ 1 ], tape.materials.front().file(3).section_numbers )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers.to_list() )
+        self.assertEqual( [ 1 ], file.section_numbers.to_list() )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers.to_list() )
+        self.assertEqual( [ 1 ], tape.materials.front().file(3).section_numbers.to_list() )
 
         # insert a section into a file
         data = copy.materials.front().file( 3 ).section( 102 )
         file.insert( data )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers )
-        self.assertEqual( [ 1, 102 ], file.section_numbers )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers )
-        self.assertEqual( [ 1, 102 ], tape.materials.front().file(3).section_numbers )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers.to_list() )
+        self.assertEqual( [ 1, 102 ], file.section_numbers.to_list() )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers.to_list() )
+        self.assertEqual( [ 1, 102 ], tape.materials.front().file(3).section_numbers.to_list() )
 
         # insert a section into a material
         data = copy.materials.front().file( 3 ).section( 2 )
         file.insert( data )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers )
-        self.assertEqual( [ 1, 2, 102 ], file.section_numbers )
-        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers )
-        self.assertEqual( [ 1, 2, 102 ], tape.materials.front().file(3).section_numbers )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], material.file_numbers.to_list() )
+        self.assertEqual( [ 1, 2, 102 ], file.section_numbers.to_list() )
+        self.assertEqual( [ 1, 3, 4, 6, 33 ], tape.materials.front().file_numbers.to_list() )
+        self.assertEqual( [ 1, 2, 102 ], tape.materials.front().file(3).section_numbers.to_list() )
 
         # insert a file into a material
         data = copy.materials.front().file( 2 )
         material.insert( data )
-        self.assertEqual( [ 1, 2, 3, 4, 6, 33 ], material.file_numbers )
-        self.assertEqual( [ 1, 2, 3, 4, 6, 33 ], tape.materials.front().file_numbers )
+        self.assertEqual( [ 1, 2, 3, 4, 6, 33 ], material.file_numbers.to_list() )
+        self.assertEqual( [ 1, 2, 3, 4, 6, 33 ], tape.materials.front().file_numbers.to_list() )
 
     def test_insert_replace_parsed_section( self ) :
 
@@ -346,7 +346,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
 
         # insert a parsed section into a file
         file.insert( data )
-        self.assertEqual( [ 1, 2, 102, 103 ], file.section_numbers )
+        self.assertEqual( [ 1, 2, 102, 103 ], file.section_numbers.to_list() )
 
         # the section was replaced correctly (testing some data)
         section = file.section( 103 ).parse()
@@ -366,7 +366,7 @@ class Test_ENDFtk_Tree_Tape( unittest.TestCase ) :
 
         # replacing a parsed section into a file
         file.insert_or_replace( data )
-        self.assertEqual( [ 1, 2, 102, 103 ], file.section_numbers )
+        self.assertEqual( [ 1, 2, 102, 103 ], file.section_numbers.to_list() )
 
         # the section was replaced correctly (testing some data)
         section = file.section( 103 ).parse()

--- a/src/ENDFtk/Material.hpp
+++ b/src/ENDFtk/Material.hpp
@@ -2,11 +2,11 @@
 #define NJOY_ENDFTK_MATERIAL
 
 // system includes
-#include <map>
+#include <list>
 #include <variant>
 
 // other includes
-#include "range/v3/view/map.hpp"
+#include "range/v3/view/all.hpp"
 #include "ENDFtk/file/1.hpp"
 #include "ENDFtk/file/2.hpp"
 #include "ENDFtk/file/3.hpp"
@@ -92,9 +92,10 @@ namespace ENDFtk {
 
     /* fields */
     int mat_;
-    std::map< int, FileVariant > files_;
+    std::list< FileVariant > files_;
 
     /* auxiliary functions */
+    #include "ENDFtk/Material/src/find.hpp"
     #include "ENDFtk/Material/src/fill.hpp"
     #include "ENDFtk/Material/src/read.hpp"
     #include "ENDFtk/Material/src/verifyMEND.hpp"
@@ -119,34 +120,22 @@ namespace ENDFtk {
     /**
      *  @brief Return the files stored in this material
      */
-    auto MFs() {
-
-      return this->files_ | ranges::cpp20::views::values;
-    }
+    auto MFs() { return this->files_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return the files stored in this material
      */
-    auto files() {
-
-      return this->MFs();
-    }
+    auto files() { return this->MFs(); }
 
     /**
      *  @brief Return the files stored in this material
      */
-    auto MFs() const {
-
-      return this->files_ | ranges::cpp20::views::values;
-    }
+    auto MFs() const { return this->files_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return the files stored in this material
      */
-    auto files() const {
-
-      return this->MFs();
-    }
+    auto files() const { return this->MFs(); }
 
     /**
      *  @brief Return an iterator to the start of the files
@@ -175,7 +164,7 @@ namespace ENDFtk {
      */
     bool hasMF( int mf ) const {
 
-      return this->files_.count( mf );
+      return this->find( mf ) != this->files_.end();
     }
 
     /**
@@ -183,10 +172,7 @@ namespace ENDFtk {
      *
      *  @param mf   the MF number of the file to be verified
      */
-    bool hasFile( int mf ) const {
-
-      return this->hasMF( mf );
-    }
+    bool hasFile( int mf ) const { return this->hasMF( mf ); }
 
     /**
      *  @brief Return whether or not the material has a section with the given
@@ -220,18 +206,17 @@ namespace ENDFtk {
      */
     const FileVariant& file( int mf ) const {
 
-      try {
+      auto iter = this->find( mf );
+      if ( iter != this->files_.end() ) {
 
-        return this->files_.at( mf );
+        return *iter;
       }
-      catch( std::out_of_range& o ) {
 
-        Log::error( "Requested file number (MF) does not"
-                    " correspond to a stored file" );
-        Log::info( "Requested file number: {}", mf );
-        Log::info( "Material queried: ", this->MAT() );
-        throw o;
-      }
+      Log::error( "Requested file number (MF) does not"
+                  " correspond to a stored file" );
+      Log::info( "Requested file number: {}", mf );
+      Log::info( "Material queried: ", this->MAT() );
+      throw std::exception();
     }
 
     /**

--- a/src/ENDFtk/Material.hpp
+++ b/src/ENDFtk/Material.hpp
@@ -2,9 +2,11 @@
 #define NJOY_ENDFTK_MATERIAL
 
 // system includes
+#include <map>
 #include <variant>
 
 // other includes
+#include "range/v3/view/map.hpp"
 #include "ENDFtk/file/1.hpp"
 #include "ENDFtk/file/2.hpp"
 #include "ENDFtk/file/3.hpp"

--- a/src/ENDFtk/Material/src/find.hpp
+++ b/src/ENDFtk/Material/src/find.hpp
@@ -1,0 +1,43 @@
+/**
+ *  @brief Return iterator to the file with the given mf number
+ *
+ *  @param[in] mt    the mf number
+ */
+auto find( int mf ) {
+
+  auto getMF = [] ( auto&& value ) { return value.MF(); };
+  auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), mf,
+                                [&getMF] ( auto&& left, auto&& right )
+                                         { return std::visit( getMF, left ) < right; } );
+
+  if ( iter != this->files_.end() ) {
+
+    if ( std::visit( getMF, *iter ) == mf ) {
+
+      return iter;
+    }
+  }
+  return this->files_.end();
+}
+
+/**
+ *  @brief Return iterator to the section with the given mf number
+ *
+ *  @param[in] mf    the mf number
+ */
+auto find( int mf ) const {
+
+  auto getMF = [] ( auto&& value ) { return value.MF(); };
+  auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), mf,
+                                [&getMF] ( auto&& left, auto&& right )
+                                         { return std::visit( getMF, left ) < right; } );
+
+  if ( iter != this->files_.end() ) {
+
+    if ( std::visit( getMF, *iter ) == mf ) {
+
+      return iter;
+    }
+  }
+  return this->files_.end();
+}

--- a/src/ENDFtk/Material/src/print.hpp
+++ b/src/ENDFtk/Material/src/print.hpp
@@ -11,7 +11,7 @@ void print( OutputIterator& it ) const {
   int MAT = this->MAT();
   for ( const auto& entry : this->files_ ) {
 
-    std::visit( [&] ( auto&& file ) { file.print( it, MAT ); }, entry.second );
+    std::visit( [&] ( auto&& file ) { file.print( it, MAT ); }, entry );
   }
   MEND().print( it );
 }

--- a/src/ENDFtk/file/Base.hpp
+++ b/src/ENDFtk/file/Base.hpp
@@ -2,10 +2,11 @@
 #define NJOY_ENDFTK_FILE_BASE
 
 // system includes
-#include <map>
+#include <list>
 
 // other includes
-#include "range/v3/view/map.hpp"
+#include "range/v3/view/all.hpp"
+#include "range/v3/view/transform.hpp"
 
 namespace njoy {
 namespace ENDFtk {
@@ -17,9 +18,10 @@ namespace file {
   protected:
 
     /* fields */
-    std::map< int, Section > sections_;
+    std::list< Section > sections_;
 
     /* auxiliary functions */
+    #include "ENDFtk/file/Base/src/find.hpp"
     #include "ENDFtk/file/Base/src/read.hpp"
     #include "ENDFtk/file/Base/src/fill.hpp"
     #include "ENDFtk/file/Base/src/verifyFEND.hpp"
@@ -34,42 +36,27 @@ namespace file {
     /**
      *  @brief Return the MF number of the file
      */
-    static constexpr int MF() {
-
-      return Derived::fileNumber();
-    }
+    static constexpr int MF() { return Derived::fileNumber(); }
 
     /**
      *  @brief Return the sections stored in this file
      */
-    auto MTs() {
-
-      return this->sections_ | ranges::cpp20::views::values;
-    }
+    auto MTs() { return this->sections_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return the sections stored in this file
      */
-    auto sections() {
-
-      return this->MTs();
-    }
+    auto sections() { return this->MTs(); }
 
     /**
      *  @brief Return the sections stored in this file
      */
-    auto MTs() const {
-
-      return this->sections_ | ranges::cpp20::views::values;
-    }
+    auto MTs() const { return this->sections_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return the sections stored in this file
      */
-    auto sections() const {
-
-      return this->MTs();
-    }
+    auto sections() const { return this->MTs(); }
 
     /**
      *  @brief Return an iterator to the start of the sections
@@ -96,20 +83,14 @@ namespace file {
      *
      *  @param mt   the MT number of the section to be verified
      */
-    bool hasMT( int mt ) const {
-
-      return this->sections_.count( mt );
-    }
+    bool hasMT( int mt ) const { return this->find( mt ) != this->sections_.end(); }
 
     /**
      *  @brief Verify if a given section (defined by the MT number) is defined
      *
      *  @param mt   the MT number of the section to be verified
      */
-    bool hasSection( int mt ) const {
-
-      return this->hasMT( mt );
-    }
+    bool hasSection( int mt ) const { return this->hasMT( mt ); }
 
     /**
      *  @brief Return the section with the requested MT number
@@ -118,18 +99,17 @@ namespace file {
      */
     const Section& section( int mt ) const {
 
-      try {
+      auto iter = this->find( mt );
+      if ( iter != this->sections_.end() ) {
 
-        return this->sections_.at( mt );
+        return *iter;
       }
-      catch( std::out_of_range& o ) {
 
-        Log::error( "Requested section number (MT) does not"
-                    " correspond to a stored section" );
-        Log::info( "Requested section number: {}", mt );
-        Log::info( "File queried: ", this->MF() );
-        throw o;
-      }
+      Log::error( "Requested section number (MT) does not"
+                  " correspond to a stored section" );
+      Log::info( "Requested section number: {}", mt );
+      Log::info( "File queried: ", this->MF() );
+      throw std::exception();
     }
 
     /**

--- a/src/ENDFtk/file/Base/src/fill.hpp
+++ b/src/ENDFtk/file/Base/src/fill.hpp
@@ -1,17 +1,24 @@
 static auto
 fill( std::vector< Section >&& sections ) {
 
-  std::map< int, Section > map;
+  std::list< Section > list;
   for ( auto&& section : sections ) {
 
     int MT = Derived::getSectionNumber( section );
-    if ( not map.emplace( MT, std::move( section ) ).second ) {
+    auto iter = std::lower_bound( list.begin(), list.end(), MT,
+                                  [] ( auto&& left, auto&& right )
+                                     { return Derived::getSectionNumber( left ) < right; } );
+    if ( iter != list.end() ) {
 
-      Log::error( "Section with duplicate section number found" );
-      Log::info( "Sections are required to specify a unique MT or section number" );
-      Log::info( "Encountered duplicate MT: {}", MT );
-      throw std::exception();
+      if ( Derived::getSectionNumber( *iter ) == MT ) {
+
+        Log::error( "Section with duplicate section number found" );
+        Log::info( "Sections are required to specify a unique MT or section number" );
+        Log::info( "Encountered duplicate MT: {}", MT );
+        throw std::exception();
+      }
     }
+    list.insert( iter, std::move( section ) );
   }
-  return map;
+  return list;
 }

--- a/src/ENDFtk/file/Base/src/find.hpp
+++ b/src/ENDFtk/file/Base/src/find.hpp
@@ -1,0 +1,41 @@
+/**
+ *  @brief Return iterator to the section with the given mt number
+ *
+ *  @param[in] mt    the mt number
+ */
+auto find( int mt ) {
+
+  auto iter = std::lower_bound( this->sections_.begin(), this->sections_.end(), mt,
+                                [] ( auto&& left, auto&& right )
+                                   { return Derived::getSectionNumber( left ) < right; } );
+
+  if ( iter != this->sections_.end() ) {
+
+    if ( Derived::getSectionNumber( *iter ) == mt ) {
+
+      return iter;
+    }
+  }
+  return this->sections_.end();
+}
+
+/**
+ *  @brief Return iterator to the section with the given mt number
+ *
+ *  @param[in] mt    the mt number
+ */
+auto find( int mt ) const {
+
+  auto iter = std::lower_bound( this->sections_.begin(), this->sections_.end(), mt,
+                                [] ( auto&& left, auto&& right )
+                                   { return Derived::getSectionNumber( left ) < right; } );
+
+  if ( iter != this->sections_.end() ) {
+
+    if ( Derived::getSectionNumber( *iter ) == mt ) {
+
+      return iter;
+    }
+  }
+  return this->sections_.end();
+}

--- a/src/ENDFtk/file/Base/src/print.hpp
+++ b/src/ENDFtk/file/Base/src/print.hpp
@@ -12,7 +12,7 @@ void print( OutputIterator& it, int MAT ) const {
   int MF = this->MF();
   for ( const auto& entry : this->sections_ ) {
 
-    Derived::printSection( entry.second, it, MAT, MF );
+    Derived::printSection( entry, it, MAT, MF );
   }
   FEND( MAT ).print( it );
 }

--- a/src/ENDFtk/tree/File.hpp
+++ b/src/ENDFtk/tree/File.hpp
@@ -2,12 +2,11 @@
 #define NJOY_ENDFTK_TREE_FILE
 
 // system includes
-#include <vector>
-#include <map>
+#include <list>
 
 // other includes
+#include "range/v3/view/all.hpp"
 #include "range/v3/view/subrange.hpp"
-#include "range/v3/view/map.hpp"
 #include "ENDFtk/file/Type.hpp"
 #include "ENDFtk/tree/Section.hpp"
 #include "ENDFtk/tree/toSection.hpp"
@@ -29,7 +28,7 @@ namespace tree {
     /* fields */
     int mat_;
     int mf_;
-    std::vector< Section > sections_;
+    std::list< Section > sections_;
 
     /* auxiliary functions */
     #include "ENDFtk/tree/File/src/find.hpp"

--- a/src/ENDFtk/tree/File.hpp
+++ b/src/ENDFtk/tree/File.hpp
@@ -29,9 +29,10 @@ namespace tree {
     /* fields */
     int mat_;
     int mf_;
-    std::map< int, Section > sections_;
+    std::vector< Section > sections_;
 
     /* auxiliary functions */
+    #include "ENDFtk/tree/File/src/find.hpp"
     #include "ENDFtk/tree/File/src/createMap.hpp"
 
   public:
@@ -66,7 +67,9 @@ namespace tree {
      */
     auto sectionNumbers() const {
 
-      return ranges::cpp20::views::keys( this->sections_ );
+      return this->sections_ | ranges::cpp20::views::transform(
+                                   [] ( auto&& section )
+                                      { return section.sectionNumber(); } );
     }
 
     #include "ENDFtk/tree/File/src/section.hpp"
@@ -93,7 +96,7 @@ namespace tree {
      */
     bool hasMT( int mt ) const {
 
-      return this->sections_.count( mt );
+      return this->find( mt ) != this->sections_.end();
     }
 
     /**
@@ -109,7 +112,7 @@ namespace tree {
      */
     auto sections() const {
 
-      return this->sections_ | ranges::cpp20::views::values;
+      return this->sections_ | ranges::cpp20::views::all;
     }
 
     /**
@@ -117,7 +120,7 @@ namespace tree {
      */
     auto sections() {
 
-      return this->sections_ | ranges::cpp20::views::values;
+      return this->sections_ | ranges::cpp20::views::all;
     }
 
     /**
@@ -125,7 +128,7 @@ namespace tree {
      */
     auto begin() const {
 
-      return ( this->sections_ | ranges::cpp20::views::values ).begin();
+      return this->sections().begin();
     }
 
     /**
@@ -133,7 +136,7 @@ namespace tree {
      */
     auto end() const {
 
-      return ( this->sections_ | ranges::cpp20::views::values ).end();
+      return this->sections().end();
     }
 
     /**
@@ -141,7 +144,7 @@ namespace tree {
      */
     auto begin() {
 
-      return ( this->sections_ | ranges::cpp20::views::values ).begin();
+      return this->sections().end();
     }
 
     /**
@@ -149,7 +152,7 @@ namespace tree {
      */
     auto end() {
 
-      return ( this->sections_ | ranges::cpp20::views::values ).end();
+      return this->sections().end();
     }
 
     /**

--- a/src/ENDFtk/tree/File.hpp
+++ b/src/ENDFtk/tree/File.hpp
@@ -31,7 +31,7 @@ namespace tree {
 
     /* auxiliary functions */
     #include "ENDFtk/tree/File/src/find.hpp"
-    #include "ENDFtk/tree/File/src/createMap.hpp"
+    #include "ENDFtk/tree/File/src/fill.hpp"
 
   public:
 

--- a/src/ENDFtk/tree/File.hpp
+++ b/src/ENDFtk/tree/File.hpp
@@ -6,7 +6,6 @@
 
 // other includes
 #include "range/v3/view/all.hpp"
-#include "range/v3/view/subrange.hpp"
 #include "ENDFtk/file/Type.hpp"
 #include "ENDFtk/tree/Section.hpp"
 #include "ENDFtk/tree/toSection.hpp"

--- a/src/ENDFtk/tree/File/src/createMap.hpp
+++ b/src/ENDFtk/tree/File/src/createMap.hpp
@@ -1,10 +1,10 @@
 template< typename BufferIterator >
-static std::vector< Section >
+static std::list< Section >
 createMap
 ( const HEAD& head, BufferIterator begin,
   BufferIterator& position, const BufferIterator& end, long& lineNumber ){
 
-  std::vector< Section > sections;
+  std::list< Section > sections;
 
   auto compare = [] ( auto&& left, auto&& right )
                     { return left.sectionNumber() < right; };

--- a/src/ENDFtk/tree/File/src/ctor.hpp
+++ b/src/ENDFtk/tree/File/src/ctor.hpp
@@ -22,7 +22,7 @@ File( const HEAD& head, BufferIterator begin,
       BufferIterator& position, const BufferIterator& end, long& lineNumber )
   try: mat_( head.MAT() ),
        mf_( head.MF() ),
-       sections_( createMap( head, begin, position, end, lineNumber ) ) {}
+       sections_( fill( head, begin, position, end, lineNumber ) ) {}
   catch ( std::exception& e ) {
 
     Log::info( "Trouble encountered while constructing an ENDF tree file" );

--- a/src/ENDFtk/tree/File/src/fill.hpp
+++ b/src/ENDFtk/tree/File/src/fill.hpp
@@ -1,6 +1,6 @@
 template< typename BufferIterator >
 static std::list< Section >
-createMap
+fill
 ( const HEAD& head, BufferIterator begin,
   BufferIterator& position, const BufferIterator& end, long& lineNumber ){
 

--- a/src/ENDFtk/tree/File/src/find.hpp
+++ b/src/ENDFtk/tree/File/src/find.hpp
@@ -1,0 +1,41 @@
+/**
+ *  @brief Return iterator to the section with the given mt number
+ *
+ *  @param[in] mt    the mt number
+ */
+auto find( int mt ) {
+
+  auto iter = std::lower_bound( this->sections_.begin(), this->sections_.end(), mt,
+                                [] ( auto&& left, auto&& right )
+                                   { return left.sectionNumber() < right; } );
+
+  if ( iter != this->sections_.end() ) {
+
+    if ( iter->sectionNumber() == mt ) {
+
+      return iter;
+    }
+  }
+  return this->sections_.end();
+}
+
+/**
+ *  @brief Return iterator to the section with the given mt number
+ *
+ *  @param[in] mt    the mt number
+ */
+auto find( int mt ) const {
+
+  auto iter = std::lower_bound( this->sections_.begin(), this->sections_.end(), mt,
+                                [] ( auto&& left, auto&& right )
+                                   { return left.sectionNumber() < right; } );
+
+  if ( iter != this->sections_.end() ) {
+
+    if ( iter->sectionNumber() == mt ) {
+
+      return iter;
+    }
+  }
+  return this->sections_.end();
+}

--- a/src/ENDFtk/tree/File/src/insertOrReplace.hpp
+++ b/src/ENDFtk/tree/File/src/insertOrReplace.hpp
@@ -19,8 +19,17 @@ void insertOrReplace( Section&& section ) {
     throw std::exception();
   }
 
-  this->remove( section.MT() );
-  this->sections_.emplace( section.MT(), std::move( section ) );
+  auto iter = std::lower_bound( this->sections_.begin(), this->sections_.end(), section.sectionNumber(),
+                                [] ( auto&& left, auto&& right )
+                                   { return left.sectionNumber() < right; } );
+  if ( iter != this->sections_.end() ) {
+
+    if ( iter->sectionNumber() == section.sectionNumber() ) {
+
+      iter = this->sections_.erase( iter );
+    }
+  }
+  this->sections_.emplace( iter, std::move( section ) );
 }
 
 /**

--- a/src/ENDFtk/tree/File/src/remove.hpp
+++ b/src/ENDFtk/tree/File/src/remove.hpp
@@ -5,7 +5,7 @@
  */
 void remove( int mt ) {
 
-  auto iter = this->sections_.find( mt );
+  auto iter = this->find( mt );
   if ( iter != this->sections_.end() ) {
 
     this->sections_.erase( iter );

--- a/src/ENDFtk/tree/File/src/section.hpp
+++ b/src/ENDFtk/tree/File/src/section.hpp
@@ -5,17 +5,16 @@
  */
 const Section& section( int mt ) const {
 
-  try {
+  auto iter = this->find( mt );
+  if ( iter != this->sections_.end() ) {
 
-    return this->sections_.at( mt );
+    return *iter;
   }
-  catch( std::out_of_range& error ) {
 
-    Log::error( "The requested section (MF{} MT{}) is not present "
-                "in the ENDF file tree",
-                this->fileNumber(), mt );
-    throw error;
-  }
+  Log::error( "The requested section (MF{} MT{}) is not present "
+              "in the ENDF file tree",
+              this->fileNumber(), mt );
+  throw std::exception();
 }
 
 /**

--- a/src/ENDFtk/tree/Material.hpp
+++ b/src/ENDFtk/tree/Material.hpp
@@ -2,10 +2,11 @@
 #define NJOY_ENDFTK_TREE_MATERIAL
 
 // system includes
-#include <vector>
-#include <map>
+#include <list>
 
 // other includes
+#include "range/v3/view/all.hpp"
+#include "range/v3/view/subrange.hpp"
 #include "ENDFtk/tree/Section.hpp"
 #include "ENDFtk/tree/toSection.hpp"
 #include "ENDFtk/tree/File.hpp"
@@ -27,9 +28,10 @@ namespace tree {
 
     /* fields */
     int mat_;
-    std::map< int, File > files_;
+    std::list< File > files_;
 
     /* auxiliary functions */
+    #include "ENDFtk/tree/Material/src/find.hpp"
     #include "ENDFtk/tree/Material/src/createMap.hpp"
 
   public:
@@ -54,7 +56,9 @@ namespace tree {
      */
     auto fileNumbers() const {
 
-      return ranges::cpp20::views::keys( this->files_ );
+      return this->files_ | ranges::cpp20::views::transform(
+                                   [] ( auto&& file )
+                                      { return file.fileNumber(); } );
     }
 
     #include "ENDFtk/tree/Material/src/file.hpp"
@@ -123,7 +127,7 @@ namespace tree {
      *
      *  @param[in]   mf   the MF number of the file
      */
-    bool hasMF( int mf ) const { return this->files_.count( mf ); }
+    bool hasMF( int mf ) const { return this->find( mf ) != this->files_.end(); }
 
     /**
      *  @brief Return whether or not the material has a file with the given MF
@@ -157,44 +161,32 @@ namespace tree {
     /**
      *  @brief Return all files in the material
      */
-    auto files() const { return this->files_ | ranges::cpp20::views::values; }
+    auto files() const { return this->files_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return all files in the material
      */
-    auto files() { return this->files_ | ranges::cpp20::views::values; }
+    auto files() { return this->files_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return a begin iterator to all files
      */
-    auto begin() const {
-
-      return ( this->files_ | ranges::cpp20::views::values ).begin();
-    }
+    auto begin() const { return this->files().begin(); }
 
     /**
      *  @brief Return an end iterator to all files
      */
-    auto end() const {
-
-      return ( this->files_ | ranges::cpp20::views::values ).end();
-    }
+    auto end() const { return this->files().end(); }
 
     /**
      *  @brief Return a begin iterator to all files
      */
-    auto begin() {
-
-      return ( this->files_ | ranges::cpp20::views::values ).begin();
-    }
+    auto begin() { return this->files().begin(); }
 
     /**
      *  @brief Return an end iterator to all files
      */
-    auto end() {
-
-      return ( this->files_ | ranges::cpp20::views::values ).end();
-    }
+    auto end() { return this->files().end(); }
 
     /**
      *  @brief Return the number of files in the materials

--- a/src/ENDFtk/tree/Material.hpp
+++ b/src/ENDFtk/tree/Material.hpp
@@ -6,7 +6,6 @@
 
 // other includes
 #include "range/v3/view/all.hpp"
-#include "range/v3/view/subrange.hpp"
 #include "ENDFtk/tree/Section.hpp"
 #include "ENDFtk/tree/toSection.hpp"
 #include "ENDFtk/tree/File.hpp"

--- a/src/ENDFtk/tree/Material.hpp
+++ b/src/ENDFtk/tree/Material.hpp
@@ -31,7 +31,7 @@ namespace tree {
 
     /* auxiliary functions */
     #include "ENDFtk/tree/Material/src/find.hpp"
-    #include "ENDFtk/tree/Material/src/createMap.hpp"
+    #include "ENDFtk/tree/Material/src/fill.hpp"
 
   public:
 

--- a/src/ENDFtk/tree/Material/src/createMap.hpp
+++ b/src/ENDFtk/tree/Material/src/createMap.hpp
@@ -1,10 +1,13 @@
 template< typename BufferIterator >
-static std::map< int, File >
+static std::list< File >
 createMap
 ( const HEAD& head, BufferIterator begin,
   BufferIterator& position, const BufferIterator& end, long& lineNumber ){
 
-  std::map< int, File > files;
+  std::list< File > files;
+
+  auto compare = [] ( auto&& left, auto&& right )
+                    { return left.fileNumber() < right; };
 
   // read the first HEAD record (we need a structure division)
   --lineNumber;
@@ -15,18 +18,23 @@ createMap
   auto mat = head.MAT();
   while ( division.isHead() && ( division.tail.MAT() == mat ) ) {
 
-    // check for duplicate mf
-    if ( files.count( division.tail.MF() ) ) {
+    auto iter = std::lower_bound( files.begin(), files.end(), division.tail.MF(), compare );
 
-      Log::error( "Found a duplicate section for MF{}", division.tail.MF() );
-      Log::info( "Current position: MAT{} MF{} MT{} at line {}",
-                 division.tail.MAT(), division.tail.MF(), division.tail.MT(),
-                 lineNumber );
-      throw std::exception();
+    // check for duplicate mf
+    if ( iter != files.end() ) {
+
+      if ( iter->fileNumber() == division.tail.MF() ) {
+
+        Log::error( "Found a duplicate section for MF{}", division.tail.MF() );
+        Log::info( "Current position: MAT{} MF{} MT{} at line {}",
+                   division.tail.MAT(), division.tail.MF(), division.tail.MT(),
+                   lineNumber );
+        throw std::exception();
+      }
     }
 
     // add the file
-    files.emplace( division.tail.MF(),
+    files.emplace( iter,
                    File( asHead( division ),
                          begin, position, end, lineNumber ) );
 

--- a/src/ENDFtk/tree/Material/src/ctor.hpp
+++ b/src/ENDFtk/tree/Material/src/ctor.hpp
@@ -20,7 +20,7 @@ template< typename BufferIterator >
 Material( const HEAD& head, BufferIterator begin, BufferIterator& position,
           const BufferIterator& end, long& lineNumber )
   try : mat_( head.MAT() ),
-        files_( createMap( head, begin, position, end, lineNumber ) ) {}
+        files_( fill( head, begin, position, end, lineNumber ) ) {}
   catch( std::exception& e ) {
 
     Log::info( "Trouble encountered while constructing a material tree." );

--- a/src/ENDFtk/tree/Material/src/file.hpp
+++ b/src/ENDFtk/tree/Material/src/file.hpp
@@ -5,20 +5,15 @@
  */
 const File& file( int mf ) const {
 
-  try {
+  auto iter = this->find( mf );
+  if ( iter != this->files_.end() ) {
 
-    return this->files_.at( mf );
+    return *iter;
   }
-  catch( std::out_of_range& o ) {
 
-    Log::error
-      ( "Requested file number (MF) does not"
-        " correspond to a stored file syntax tree" );
-    Log::info( "Requested file number: {}", mf );
-    Log::info( "Material number of queried material syntax tree: ",
-               this->materialNumber() );
-    throw o;
-  }
+  Log::error( "The requested file (MF{}) is not present "
+              "in the ENDF file tree", mf );
+  throw std::exception();
 }
 
 /**

--- a/src/ENDFtk/tree/Material/src/fill.hpp
+++ b/src/ENDFtk/tree/Material/src/fill.hpp
@@ -1,6 +1,6 @@
 template< typename BufferIterator >
 static std::list< File >
-createMap
+fill
 ( const HEAD& head, BufferIterator begin,
   BufferIterator& position, const BufferIterator& end, long& lineNumber ){
 

--- a/src/ENDFtk/tree/Material/src/find.hpp
+++ b/src/ENDFtk/tree/Material/src/find.hpp
@@ -1,0 +1,41 @@
+/**
+ *  @brief Return iterator to the file with the given mf number
+ *
+ *  @param[in] mf    the mf number
+ */
+auto find( int mf ) {
+
+  auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), mf,
+                                [] ( auto&& left, auto&& right )
+                                   { return left.fileNumber() < right; } );
+
+  if ( iter != this->files_.end() ) {
+
+    if ( iter->fileNumber() == mf ) {
+
+      return iter;
+    }
+  }
+  return this->files_.end();
+}
+
+/**
+ *  @brief Return iterator to the file with the given mf number
+ *
+ *  @param[in] mf    the mf number
+ */
+auto find( int mf ) const {
+
+  auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), mf,
+                                [] ( auto&& left, auto&& right )
+                                   { return left.fileNumber() < right; } );
+
+  if ( iter != this->files_.end() ) {
+
+    if ( iter->fileNumber() == mf ) {
+
+      return iter;
+    }
+  }
+  return this->files_.end();
+}

--- a/src/ENDFtk/tree/Material/src/insert.hpp
+++ b/src/ENDFtk/tree/Material/src/insert.hpp
@@ -15,7 +15,11 @@ void insert( Section&& section ) {
 
   if ( !this->hasMF( section.MF() ) ) {
 
-    this->files_.emplace( section.MF(), File( this->MAT(), section.MF() ) );
+    auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), section.fileNumber(),
+                                  [] ( auto&& left, auto&& right )
+                                     { return left.fileNumber() < right; } );
+
+    this->files_.emplace( iter, File( this->MAT(), section.MF() ) );
   }
 
   this->MF( section.MF() ).insert( std::move( section ) );

--- a/src/ENDFtk/tree/Material/src/insertOrReplace.hpp
+++ b/src/ENDFtk/tree/Material/src/insertOrReplace.hpp
@@ -12,7 +12,11 @@ void insertOrReplace( Section&& section ) {
 
   if ( !this->hasMF( section.MF() ) ) {
 
-    this->files_.emplace( section.MF(), File( this->MAT(), section.MF() ) );
+    auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), section.fileNumber(),
+                                  [] ( auto&& left, auto&& right )
+                                     { return left.fileNumber() < right; } );
+
+    this->files_.emplace( iter, File( this->MAT(), section.MF() ) );
   }
 
   this->MF( section.MF() ).insertOrReplace( std::move( section ) );
@@ -57,8 +61,17 @@ void insertOrReplace( File&& file ) {
     throw std::exception();
   }
 
-  this->remove( file.MF() );
-  this->files_.emplace( file.MF(), std::move( file ) );
+  auto iter = std::lower_bound( this->files_.begin(), this->files_.end(), file.fileNumber(),
+                                [] ( auto&& left, auto&& right )
+                                   { return left.fileNumber() < right; } );
+  if ( iter != this->files_.end() ) {
+
+    if ( iter->fileNumber() == file.fileNumber() ) {
+
+      iter = this->files_.erase( iter );
+    }
+  }
+  this->files_.emplace( iter, std::move( file ) );
 }
 
 /**

--- a/src/ENDFtk/tree/Material/src/remove.hpp
+++ b/src/ENDFtk/tree/Material/src/remove.hpp
@@ -5,7 +5,7 @@
  */
 void remove( int mf ) {
 
-  auto iter = this->files_.find( mf );
+  auto iter = this->find( mf );
   if ( iter != this->files_.end() ) {
 
     this->files_.erase( iter );
@@ -20,9 +20,9 @@ void remove( int mf ) {
  */
 void remove( int mf, int mt ) {
 
-  auto iter = this->files_.find( mf );
+  auto iter = this->find( mf );
   if ( iter != this->files_.end() ) {
 
-    iter->second.remove( mt );
+    iter->remove( mt );
   }
 }

--- a/src/ENDFtk/tree/Tape.hpp
+++ b/src/ENDFtk/tree/Tape.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 
 // other includes
+#include "range/v3/view/map.hpp"
 #include "range/v3/action/sort.hpp"
 #include "range/v3/action/unique.hpp"
 #include "range/v3/range/operations.hpp"

--- a/src/ENDFtk/tree/Tape.hpp
+++ b/src/ENDFtk/tree/Tape.hpp
@@ -3,7 +3,7 @@
 
 // system includes
 #include <vector>
-#include <map>
+#include <list>
 #include <optional>
 
 // other includes
@@ -37,9 +37,10 @@ namespace tree {
 
     /* fields */
     std::optional< TapeIdentification > tpid_;
-    std::multimap< int, Material > materials_;
+    std::list< Material > materials_;
 
     /* auxiliary function */
+    #include "ENDFtk/tree/Tape/src/find.hpp"
     #include "ENDFtk/tree/Tape/src/createMap.hpp"
 
   public:
@@ -80,7 +81,8 @@ namespace tree {
      */
     int numberMAT( int mat ) const {
 
-      return this->materials_.count( mat );
+      auto range = this->find( mat );
+      return std::distance( range.first, range.second );
     }
 
     /**
@@ -99,7 +101,8 @@ namespace tree {
      */
     bool hasMAT( int mat ) const {
 
-      return this->materials_.count( mat );
+      auto range = this->find( mat );
+      return range.first != range.second;
     }
 
     /**
@@ -113,18 +116,12 @@ namespace tree {
     /**
      *  @brief Return all materials in the tape
      */
-    auto materials() {
-
-      return this->materials_ | ranges::cpp20::views::values;
-    }
+    auto materials() { return this->materials_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return all materials in the tape
      */
-    auto materials() const {
-
-      return this->materials_ | ranges::cpp20::views::values;
-    }
+    auto materials() const { return this->materials_ | ranges::cpp20::views::all; }
 
     /**
      *  @brief Return a begin iterator to all materials
@@ -157,7 +154,7 @@ namespace tree {
     auto content() const {
 
       std::string content;
-      if ( this->tpid_ ) {
+      if ( this->tpid_.has_value() ) {
 
         auto output = std::back_inserter( content );
         this->tpid_->print( output, 0, 0, 0 );
@@ -187,9 +184,14 @@ namespace tree {
      */
     std::vector< int > materialNumbers() const {
 
-      return ranges::cpp20::views::keys( this->materials_ )
-               | ranges::to_vector
-               | ranges::actions::sort | ranges::actions::unique;
+      using namespace njoy::tools;
+      auto keys = this->materials_ | ranges::cpp20::views::transform(
+                                         [] ( auto&& material )
+                                            { return material.materialNumber(); } );
+      std::vector< int > materials( keys.begin(), keys.end() );
+      std::sort( materials.begin(), materials.end() );
+      materials.erase( std::unique( materials.begin(), materials.end() ), materials.end() );
+      return materials;
     }
 
     #include "ENDFtk/tree/Tape/src/remove.hpp"

--- a/src/ENDFtk/tree/Tape.hpp
+++ b/src/ENDFtk/tree/Tape.hpp
@@ -41,7 +41,7 @@ namespace tree {
 
     /* auxiliary function */
     #include "ENDFtk/tree/Tape/src/find.hpp"
-    #include "ENDFtk/tree/Tape/src/createMap.hpp"
+    #include "ENDFtk/tree/Tape/src/fill.hpp"
 
   public:
 

--- a/src/ENDFtk/tree/Tape.hpp
+++ b/src/ENDFtk/tree/Tape.hpp
@@ -138,10 +138,7 @@ namespace tree {
     /**
      *  @brief Return a begin iterator to all materials
      */
-    auto begin() const {
-
-      return this->materials().begin();
-    }
+    auto begin() const { return this->materials().begin(); }
 
     /**
      *  @brief Return an end iterator to all materials

--- a/src/ENDFtk/tree/Tape/src/createMap.hpp
+++ b/src/ENDFtk/tree/Tape/src/createMap.hpp
@@ -3,15 +3,20 @@ static auto
 createMap( BufferIterator position, const BufferIterator& end,
            long& lineNumber ) {
 
-  std::multimap< int, Material > materials;
+  std::list< Material > materials;
+
+  auto compare = [] ( auto&& left, auto&& right )
+                    { return left < right.materialNumber(); };
 
   auto begin = position;
   auto division = StructureDivision( position, end, lineNumber );
 
   while ( division.isHead() ) {
 
+    auto iter = std::upper_bound( materials.begin(), materials.end(), division.tail.MAT(), compare );
+
     materials.emplace(
-      division.tail.MAT(),
+      iter,
       Material( asHead( division ), begin, position, end, lineNumber ) );
 
     begin = position;

--- a/src/ENDFtk/tree/Tape/src/ctor.hpp
+++ b/src/ENDFtk/tree/Tape/src/ctor.hpp
@@ -18,7 +18,7 @@ Tape( const Buffer& buffer, long lineNumber = 0 )
     auto position = ranges::cpp20::begin( buffer );
     auto end = ranges::cpp20::end( buffer );
     this->tpid_ = TapeIdentification{ position, end, lineNumber };
-    materials_ = createMap( position, end, lineNumber );
+    materials_ = fill( position, end, lineNumber );
   }
   catch ( std::exception& e ) {
 

--- a/src/ENDFtk/tree/Tape/src/fill.hpp
+++ b/src/ENDFtk/tree/Tape/src/fill.hpp
@@ -1,7 +1,6 @@
 template < typename BufferIterator >
 static auto
-createMap( BufferIterator position, const BufferIterator& end,
-           long& lineNumber ) {
+fill( BufferIterator position, const BufferIterator& end, long& lineNumber ) {
 
   std::list< Material > materials;
 
@@ -44,8 +43,8 @@ createMap( BufferIterator position, const BufferIterator& end,
 
 template < typename BufferIterator >
 static auto
-createMap( BufferIterator position, const BufferIterator& end ){
+fill( BufferIterator position, const BufferIterator& end ){
 
   long lineNumber{ 0 };
-  return createMap( position, end, lineNumber );
+  return fill( position, end, lineNumber );
 }

--- a/src/ENDFtk/tree/Tape/src/find.hpp
+++ b/src/ENDFtk/tree/Tape/src/find.hpp
@@ -1,0 +1,41 @@
+/**
+ *  @brief Return iterator to the file with the given mat number
+ *
+ *  @param[in] mat    the mat number
+ */
+auto find( int mat ) {
+
+  auto lower = std::lower_bound( this->materials_.begin(), this->materials_.end(), mat,
+                                 [] ( auto&& left, auto&& right )
+                                    { return left.materialNumber() < right; } );
+  auto upper = std::upper_bound( this->materials_.begin(), this->materials_.end(), mat,
+                                 [] ( auto&& left, auto&& right )
+                                    { return left < right.materialNumber(); } );
+
+  if ( lower != upper ) {
+
+    return std::make_pair( lower, upper );
+  }
+  return std::make_pair( this->materials_.end(), this->materials_.end() );
+}
+
+/**
+ *  @brief Return iterator to the file with the given mat number
+ *
+ *  @param[in] mat    the mat number
+ */
+auto find( int mat ) const {
+
+  auto lower = std::lower_bound( this->materials_.begin(), this->materials_.end(), mat,
+                                 [] ( auto&& left, auto&& right )
+                                    { return left.materialNumber() < right; } );
+  auto upper = std::upper_bound( this->materials_.begin(), this->materials_.end(), mat,
+                                 [] ( auto&& left, auto&& right )
+                                    { return left < right.materialNumber(); } );
+
+  if ( lower != upper ) {
+
+    return std::make_pair( lower, upper );
+  }
+  return std::make_pair( this->materials_.end(), this->materials_.end() );
+}

--- a/src/ENDFtk/tree/Tape/src/insert.hpp
+++ b/src/ENDFtk/tree/Tape/src/insert.hpp
@@ -9,7 +9,12 @@
  */
 void insert( Material&& material ) {
 
-  this->materials_.emplace( material.MAT(), std::move( material ) );
+  auto compare = [] ( auto&& left, auto&& right )
+                    { return left < right.materialNumber(); };
+  auto iter = std::upper_bound( this->materials_.begin(), this->materials_.end(),
+                                material.MAT(), compare );
+
+  this->materials_.emplace( iter, std::move( material ) );
 }
 
 /**

--- a/src/ENDFtk/tree/Tape/src/material.hpp
+++ b/src/ENDFtk/tree/Tape/src/material.hpp
@@ -9,7 +9,8 @@
  */
 auto material( int mat ) const {
 
-  if ( not this->materials_.count( mat ) ) {
+  auto range = this->find( mat );
+  if ( range.first ==  range.second ) {
 
     Log::error( "Requested material number (MAT) does not"
                 " correspond to a stored material syntax tree" );
@@ -17,10 +18,9 @@ auto material( int mat ) const {
     throw std::out_of_range( "Requested material number (MAT) does not"
                              " correspond to a stored material tree" );
   }
-  auto bounds = this->materials_.equal_range( mat );
   return
-    ranges::make_subrange( bounds.first, bounds.second )
-    | ranges::cpp20::views::values;
+    ranges::make_subrange( range.first, range.second )
+    | ranges::cpp20::views::all;
 }
 
 /**

--- a/src/ENDFtk/tree/Tape/src/remove.hpp
+++ b/src/ENDFtk/tree/Tape/src/remove.hpp
@@ -5,5 +5,6 @@
  */
 void remove( int mat ) {
 
-  this->materials_.erase( mat );
+  auto range = this->find( mat );
+  this->materials_.erase( range.first, range.second );
 }

--- a/src/ENDFtk/tree/Tape/src/replace.hpp
+++ b/src/ENDFtk/tree/Tape/src/replace.hpp
@@ -10,7 +10,12 @@
 void replace( Material&& material ) {
 
   this->remove( material.MAT() );
-  this->materials_.emplace( material.MAT(), std::move( material ) );
+  auto compare = [] ( auto&& left, auto&& right )
+                    { return left.materialNumber() < right; };
+  auto lower = std::lower_bound( this->materials_.begin(), this->materials_.end(),
+                                 material.materialNumber(), compare );
+
+  this->materials_.emplace( lower, std::move( material ) );
 }
 
 /**


### PR DESCRIPTION
Another PR to prepare for the removal of range-v3.

The tree::Tape, tree::File, tree::Section and the parsed equivalents all use std::map or std::multimap to store their information and we use views::keys and views::elements to access the data as ranges (bidirectional ones).

Trials with the replacement of range-v3 have shown issues with the views::keys and views::elements replacements that cause compilation errors. Since these are basically implementation details, I decided to replace the maps and multimaps with lists. This does not break the interface as the entire interface still behaves in the same way (we can iterate over materials, files, sections, etc. as bidirectional ranges).

I did try using vector instead of list but the removal and insertion of sections/files/materials was broken by this change. Lists allow elements to be inserted without invalidating iterators while vectors do not. As a result, keeping a reference around to an element after inserting an element in a vector may be dangerous. Because of this, I went back to lists which maintains the current interface.